### PR TITLE
Add new keyword HOSTLIB_MNINTFLUX_SNPOS 

### DIFF
--- a/src/snlc_sim.c
+++ b/src/snlc_sim.c
@@ -1014,6 +1014,7 @@ void set_user_defaults(void) {
   INPUTS.HOSTLIB_USE    = 0;
   INPUTS.HOSTLIB_MSKOPT = 0;
   INPUTS.HOSTLIB_MAXREAD     = 1000000000 ; // default is 1 billion
+  INPUTS.HOSTLIB_MNINTFLUX_SNPOS = 0.00 ;  // use 0% as the minimum limit for SNPOS
   INPUTS.HOSTLIB_MXINTFLUX_SNPOS = 0.99 ;  // use 99% of total flux for SNPOS
   INPUTS.HOSTLIB_GALID_NULL      = -9;     // value for no host
   INPUTS.HOSTLIB_GALID_PRIORITY[0]  = 0 ;
@@ -3127,6 +3128,9 @@ int parse_input_HOSTLIB(char **WORDS, int keySource ) {
   }
   else if ( keyMatchSim(1, "HOSTLIB_MINDAYSEP_SAMEGAL",WORDS[0],keySource) ) {
     N++;  sscanf(WORDS[N], "%d", &INPUTS.HOSTLIB_MINDAYSEP_SAMEGAL);
+  }
+  else if ( keyMatchSim(1, "HOSTLIB_MNINTFLUX_SNPOS",WORDS[0],keySource) ) {
+    N++;  sscanf(WORDS[N], "%f", &INPUTS.HOSTLIB_MNINTFLUX_SNPOS);
   }
   else if ( keyMatchSim(1, "HOSTLIB_MXINTFLUX_SNPOS",WORDS[0],keySource) ) {
     N++;  sscanf(WORDS[N], "%f", &INPUTS.HOSTLIB_MXINTFLUX_SNPOS);

--- a/src/snlc_sim.h
+++ b/src/snlc_sim.h
@@ -464,6 +464,7 @@ struct INPUTS {
   int  HOSTLIB_GALID_NULL ;     // value for no galaxy; default is -9
   int  HOSTLIB_GALID_PRIORITY[2] ;    // preferentially select this GALID range
   int  HOSTLIB_MINDAYSEP_SAMEGAL ;    // min DAYs before re-using host gal  
+  float  HOSTLIB_MNINTFLUX_SNPOS; // gen SNPOS greater than this flux-fraction (.00)
   float  HOSTLIB_MXINTFLUX_SNPOS; // gen SNPOS within this flux-fraction (.99)
   float  HOSTLIB_GENRANGE_NSIGZ[2];  // allowed range of (Zphot-Z)/Zerr
   float  HOSTLIB_MAXDDLR ;             // keep hosts with DDLR < MAXDDLR

--- a/src/sntools_host.c
+++ b/src/sntools_host.c
@@ -556,6 +556,18 @@ void  checkAbort_HOSTLIB(void) {
     errmsg(SEV_FATAL, 0, fnam, c1err, c2err); 
   }
 
+  if (INPUTS.HOSTLIB_MNINTFLUX_SNPOS < 0) {
+    sprintf ( c1err, "Cannot have negative value for");
+    sprintf ( c2err, "HOSTLIB_MNINTFLUX_SNPOS");
+    errmsg(SEV_FATAL, 0, fnam, c1err, c2err); 
+  }
+
+  if (INPUTS.HOSTLIB_MNINTFLUX_SNPOS > INPUTS.HOSTLIB_MXINTFLUX_SNPOS) {
+    sprintf ( c1err, "Cannot have HOSTLIB min sep > max sep");
+    sprintf ( c2err, "MNINTFLUX_SNPOS > MXINTFLUX_SNPOS");
+    errmsg(SEV_FATAL, 0, fnam, c1err, c2err); 
+  }
+
 
   return ;
 } // end checkAbort_HOSTLIB
@@ -4706,8 +4718,8 @@ void readme_HOSTLIB(void) {
   }
 
   cptr = HOSTLIB.COMMENT[NTMP]; NTMP++ ; 
-  sprintf(cptr,"GALPOS generated with %5.4f of total flux.",
-	  INPUTS.HOSTLIB_MXINTFLUX_SNPOS);
+  sprintf(cptr,"GALPOS generated with %5.4f -- %5.4f of total flux.",
+	  INPUTS.HOSTLIB_MNINTFLUX_SNPOS, INPUTS.HOSTLIB_MXINTFLUX_SNPOS);
 
 
   // print out list of aperture radii
@@ -6088,7 +6100,10 @@ void GEN_SNHOST_POS(int IGAL) {
   // To limit very distant SN from the long Sersic tails,
   // 'MXINTFLUX_SNPOS' of the integrated flux is used to
   // determine the reduced radius.
-  RanInteg    = Ran1 * INPUTS.HOSTLIB_MXINTFLUX_SNPOS ;
+  //
+  //XXX DELETE RanInteg    = Ran1 * INPUTS.HOSTLIB_MXINTFLUX_SNPOS ;
+  //GN - added min int flux to allow min offset from host center
+  RanInteg    = INPUTS.HOSTLIB_MNINTFLUX_SNPOS + Ran1 * (INPUTS.HOSTLIB_MXINTFLUX_SNPOS - INPUTS.HOSTLIB_MNINTFLUX_SNPOS) ;
   ptr_r       = SERSIC_TABLE.reduced_logR ;  
   ptr_integ0  = SERSIC_TABLE.INTEG_CUM[k_table] ;
   ptr_integ1  = SERSIC_TABLE.INTEG_CUM[k_table+1] ;

--- a/src/sntools_output.h
+++ b/src/sntools_output.h
@@ -34,7 +34,7 @@
 
 
 // define flags for software packages
-#define USE_HBOOK  
+#define USE_HBOOKXXX  
 #define USE_ROOT     
 #define USE_TEXT  // always leave this on; same logic as for HBOOK,ROOT, ...
 #define USE_MARZ  // always leave this on


### PR DESCRIPTION
Keywords allow kicks from host centroid for specific classes of transients when generated with snlc_sim.exe
Also added checks to make sure MN > 0 and MX > MN