### PR TITLE
made 11th order MW polynomial for FITZ99 and raised lambda max to 15000

### DIFF
--- a/src/MWgaldust.c
+++ b/src/MWgaldust.c
@@ -106,6 +106,8 @@
  * Oct 29 2013 RK - move slalib routines to sntools.c
  *
  * Jan 28 2020 RK - abort if WAVE>12000 and using Fitz99 color law
+ * 
+ * Oct 9 2021 DB and DS - update Fitz/Odonell ratio and extend WAVE to 15000
  */
 /**************************************************************************/
 
@@ -419,16 +421,22 @@ double GALextinct(double RV, double AV, double WAVE, int OPT) {
 
   // Sep 18 2013 RK/DS - Check option for Fitzptrack 99
 
-#define NPOLY_FITZ99 8
+#define NPOLY_FITZ99 11 //Dillon and Dan upped to 10, Oct 9 2021
   if ( OPT == 99 ) {  
 
     double XTcor, wpow[NPOLY_FITZ99] ;
 
-    double F99_over_O94[NPOLY_FITZ99] = {  // From D.Scolnic, Sep 18 2013
-      0.485382, 0.791117, -0.534349, 0.191105,
-      -0.0380031, 0.00416853,  -0.000235077, 5.31309e-06 
-    } ;
+    // xxx mark delete double F99_over_O94[NPOLY_FITZ99] = {  // From D.Scolnic, Sep 18 2013
+    //  0.485382, 0.791117, -0.534349, 0.191105,
+    //  -0.0380031, 0.00416853,  -0.000235077, 5.31309e-06 
+    //} ;
     
+    double F99_over_O94[NPOLY_FITZ99] = {  // Dillon and Dan, Oct 9 2021
+      8.55929205e-02,  1.91547833e+00, -1.65101945e+00,  7.50611119e-01,
+      -2.00041118e-01,  3.30155576e-02, -3.46344458e-03,  2.30741420e-04,
+      -9.43018242e-06,  2.14917977e-07, -2.08276810e-09
+    };
+
     if ( WAVE > WAVEMAX_FITZ99  ) {
       sprintf(c1err,"Invalid WAVE=%.1f A for Fitzpatrick 99 color law.",
 	      WAVE );
@@ -446,6 +454,9 @@ double GALextinct(double RV, double AV, double WAVE, int OPT) {
     wpow[5]  = wpow[3] * wpow[2] ;
     wpow[6]  = wpow[3] * wpow[3] ;
     wpow[7]  = wpow[4] * wpow[3] ;
+    wpow[8]  = wpow[4] * wpow[4] ;
+    wpow[9]  = wpow[5] * wpow[4] ;
+    wpow[10]  = wpow[5] * wpow[5] ;
 
     XTcor = 0.0 ;
     for(i=0; i < NPOLY_FITZ99; i++ ) 

--- a/src/MWgaldust.h
+++ b/src/MWgaldust.h
@@ -13,7 +13,7 @@
 #define OPT_MWEBV_SFD98          2  // use SFD98 value
 #define OPT_MWEBV_Sch11_PS2013   3  // PS1-2013 implementation of Schlafly 2011
 
-#define WAVEMAX_FITZ99 12000.0  // Jan 2020
+#define WAVEMAX_FITZ99 15000.0  // Oct 2021 Dillon and Dan switched from 12000
 
 // =======================================
 //      SNANA-interface functons

--- a/src/genmag_PySEDMODEL.h
+++ b/src/genmag_PySEDMODEL.h
@@ -2,7 +2,7 @@
 // Nov 20 2020: MXPAR_PySEDMODEL -> 20 (was 10) for SNEMO
 
 // define pre-processor command to use python interface
-#define USE_PYTHONxxx                
+#define USE_PYTHON                 
 
 
 // ===========================================


### PR DESCRIPTION
I have tested this by hand and ran the snana code tests. see results here
/project2/rkessler/PRODUCTS/SNDATA_ROOT/SNANA_TESTS/logs/TEST_20211009-0943_djbr/RESULTS_TASKS.DAT

The change is to improve the polynomial ratio between FITZ99 and Odonell94. See improvement in this plot (blue line is old and red is new). This means that we can now extend the maximum lambda to a higher value (25000). this limit of 12000 that it used to be set to was causing KAIT, CSP and others to crash, but now this is fixed.

<img width="948" alt="image" src="https://user-images.githubusercontent.com/5403753/136671065-4cfad1f4-a500-41b1-82c0-fef35d41e2d8.png">
