### PR TITLE
Added --func and --plot. Sped up when using --nrow

### DIFF
--- a/util/get_fitres_values.py
+++ b/util/get_fitres_values.py
@@ -18,6 +18,7 @@
 
 import os, sys, argparse, gzip
 import plotext as plt
+import numpy as np
 import pandas as pd
 
 KEYLIST_DOCANA = [ 'DOCUMENTATION:', 'DOCUMENTATION_END:' ]
@@ -259,7 +260,13 @@ def print_info(info_fitres):
 
     if plot == "hist":
         for var in var_list:
-            plt.hist(df[var].to_list(), label=var)
+            data = df[var]
+            q1 = data.quantile(0.25)
+            q3 = data.quantile(0.75)
+            iqr = q3 - q1
+            bin_width = (2 * iqr) / (len(data) ** (1 / 3))
+            bin_count = int(np.ceil((data.max() - data.min()) / bin_width))
+            plt.hist(df[var].to_list(), bins=bin_count, label=var)
         plt.show()
 
     if plot == "scatter":


### PR DESCRIPTION
This commit makes three changes to get_fitres_values.py.

1. When loading the fitres file via `pd.read_csv` added `nrows` key when `--nrow` defined. This only loads the first `nrow` rows, after skipping all comments and DOCANA, dramatically speeding up the rest of the code.
2. Added a `--func` key, which can be a comma seperated list of either `mean`, `min`, or `max`. This will print the mean, min, or max of the provided dataframe. Note that this will work _even if `--nrow` or `--cid` is not defined_, meaning you are able to get the mean, min, or max or the entire fitres file.
3. Added the `--plot` key, which can either be `hist` or `scatter`. This uses [plotext](https://pypi.org/project/plotext/) to plot the histogram or scatter plot of the given variables **directly into the terminal** meaning no x server is required and it will work perfectly fine over ssh. Once again, if `--nrow` or `--cid` are not defined, this will create a plot for the entire fitres file.

I also added a few input checks during the parsing stage:
1. If `--cid` and `--nrow` are not defined then either `--func` or `--plot` must be defined
2. If `--plot scatter` is defined, then you are only allowed to define 2 variables.

These changes should make quick statistical checks of a fitres file much quicker and easier. For instance, if you have a few outliers which are causing issues down the line you can use the `hist` plot to get an idea for a good cutoff. This would help in the case of #941 for instance