### PR TITLE
Refactor pySED model interface

### DIFF
--- a/src/genmag_PySEDMODEL.c
+++ b/src/genmag_PySEDMODEL.c
@@ -574,8 +574,7 @@ int fetchParNames_PySEDMODEL(char **parNameList) {
   // python declarations here
 
   int ipar;
-  PyObject *parnamesmeth,*pNames,*pNPARmeth,*pNPAR,*pnamesitem;
-  PyListObject *arrNames;
+  PyObject *parnamesmeth,*pNames,*pnamesitem;
   printf("fetching parameter names from Python\n");
   // David: need your python magic to return these string names.
 
@@ -585,27 +584,21 @@ int fetchParNames_PySEDMODEL(char **parNameList) {
   //xx  parnamesmeth  = PyObject_GetAttrString(geninit_PySEDMODEL,
   //xx					 "fetchParNames_BYOSED");
 
-  sprintf(pyfun_tmp, "fetchNParNames_%s", MODEL_NAME );
-
-  pNPARmeth  = PyObject_GetAttrString(geninit_PySEDMODEL, pyfun_tmp);
-  // xxx  pNPARmeth  = PyObject_GetAttrString(geninit_PySEDMODEL,
-  // xxx			      "fetchNParNames_BYOSED");
-
   pNames  = PyEval_CallObject(parnamesmeth, NULL);
-  pNPAR  = PyEval_CallObject(pNPARmeth, NULL);
-
-  NPAR = PyLong_AsLong(pNPAR);
-  arrNames = (PyListObject *)(pNames);
+  if (PySequence_Check(pNames) != 0) {
+    sprintf(c1err,"%s is expected to return a sequence of str, for example a list", pyfun_tmp);
+    sprintf(c2err,"but it is %s instead", PyUnicode_AsUTF8(PyObject_Type(pNames)));
+    errmsg(SEV_FATAL, 0, fnam, c1err, c2err);
+  }
+  NPAR = PySequence_Length(pNames);
   for(ipar=0; ipar < NPAR; ipar++ ) {
-    pnamesitem = PyList_GetItem(arrNames,ipar);
+    pnamesitem = PySequence_GetItem(pNames,ipar);
     sprintf(parNameList[ipar],PyUnicode_AsUTF8(pnamesitem));
+    Py_DECREF(pnamesitem);
   }
 
-  Py_DECREF(arrNames);
   Py_DECREF(pNames);
   Py_DECREF(parnamesmeth);
-  Py_DECREF(pNPARmeth);
-  Py_DECREF(pNPAR);
 
 #endif
 

--- a/src/genmag_PySEDMODEL.h
+++ b/src/genmag_PySEDMODEL.h
@@ -31,7 +31,7 @@ struct {
 
   // stuff determined from inputs above
   char  MODEL_NAME[40] ; // e.g., BYOSED, SNEMO ....
-  char  PyFUN_NAME[60] ; // e.g., genmag_BYOSED
+  char  PyCLASS_NAME[60] ; // e.g., genmag_BYOSED
 
 } INPUTS_PySEDMODEL ;
 

--- a/src/gensed_BAYESN.py
+++ b/src/gensed_BAYESN.py
@@ -15,6 +15,8 @@ import scipy.stats as st
 from scipy.interpolate import RegularGridInterpolator
 import matplotlib.pyplot as plt
 
+from gensed_base import gensed_base
+
 
 mask_bit_locations = {'verbose':1,'dump':2}
 DEFAULT_BAYESN_MODEL='M20'
@@ -33,7 +35,7 @@ def print_err():
   raise RuntimeError
 
 
-class gensed_BAYESN:
+class gensed_BAYESN(gensed_base):
     def __init__(self,PATH_VERSION,OPTMASK,ARGLIST,HOST_PARAM_NAMES):
 
         try:
@@ -234,7 +236,7 @@ class gensed_BAYESN:
 
                     elif distrib_name == 'PEAK':
                         # we have only a peak - just set this as a scalar
-                        self.setParVals_BAYESN(param=float(val))
+                        self.setParVals(param=float(val))
             else:
                 # if we have more than one parameter specified
                 # then we are specifying a Gaussian of some sort
@@ -257,7 +259,7 @@ class gensed_BAYESN:
                 # if peak is specified and sigma is not, we've either got a range and checked
                 # or we've not got a range and whatever - it's still a valid fixed value
                 if sigma is None and peak is not None:
-                    self.setParVals_BAYESN(param=float(peak))
+                    self.setParVals(param=float(peak))
 
                 if peak is not None and sigma is not None:
                     if llim is not None and ulim is not None:
@@ -277,10 +279,10 @@ class gensed_BAYESN:
         """
         Returns the wavelength vector
         """
-        return np.asarray(self.wave)
+        return self.wave
 
 
-    def fetchSED_BAYESN(self, trest, maxlam=5000, external_id=1, new_event=1, hostpars=''):
+    def fetchSED(self, trest, maxlam=5000, external_id=1, new_event=1, hostpars=''):
         """
         Returns the flux at every wavelength, for a given phase.
 
@@ -325,7 +327,7 @@ class gensed_BAYESN:
             if self.verbose:
                 print(useful_pars, 'set')
 
-            self.setParVals_BAYESN(**useful_pars)
+            self.setParVals(**useful_pars)
 
 
         #ST: Three lines originally from GSN
@@ -372,10 +374,10 @@ class gensed_BAYESN:
         flux = np.exp(-GAMMA*(self.M0 + self.parameter_values["DELTAM"]))*S_tilde
 
         ########## ORIGINAL RETURN STATEMENT FROM GSN ##########
-        return np.asarray(flux)
+        return flux
 
 
-    def setParVals_BAYESN(self, **kwargs):
+    def setParVals(self, **kwargs):
         """
         Sets the values of parameter names
         """
@@ -388,14 +390,14 @@ class gensed_BAYESN:
         self.parameter_values.update(kwargs)
 
 
-    def fetchParNames_BAYESN(self):
+    def fetchParNames(self):
         """
         Returns the names of model parameters
         """
         return list(self.parameter_names)
 
 
-    def fetchParVals_BAYESN_4SNANA(self,varname):
+    def fetchParVals(self,varname):
         """
         Returns the value of parameter 'varname'
 
@@ -546,16 +548,16 @@ def main():
 
     fig = plt.figure(figsize=(10, 5))
     ax1 = fig.add_subplot(111)
-    mySED.setParVals_BAYESN(THETA1=0., AV=0.1 , RV=3.1 , DELTAM=0.  , TMAX=0.)
-    flux = mySED.fetchSED_BAYESN(0, new_event=2)
+    mySED.setParVals(THETA1=0., AV=0.1 , RV=3.1 , DELTAM=0.  , TMAX=0.)
+    flux = mySED.fetchSED(0, new_event=2)
     ax1.plot(mySED.wave, np.array(flux), 'g-')
 
-    mySED.setParVals_BAYESN(THETA1=2., AV=0.3 , RV=3.1 , DELTAM=0.  , TMAX=0.)
-    flux = mySED.fetchSED_BAYESN(0, new_event=2)
+    mySED.setParVals(THETA1=2., AV=0.3 , RV=3.1 , DELTAM=0.  , TMAX=0.)
+    flux = mySED.fetchSED(0, new_event=2)
     ax1.plot(mySED.wave, np.array(flux), 'r-')
 
-    mySED.setParVals_BAYESN(THETA1=-1.7, AV=0. , RV=3.1 , DELTAM=0.5 , TMAX=0.)
-    flux = mySED.fetchSED_BAYESN(0, new_event=2)
+    mySED.setParVals(THETA1=-1.7, AV=0. , RV=3.1 , DELTAM=0.5 , TMAX=0.)
+    flux = mySED.fetchSED(0, new_event=2)
     ax1.plot(mySED.wave, np.array(flux), 'b-')
 
     ax1.plot(mySED.wave, np.array(flux))
@@ -566,16 +568,16 @@ def main():
     ind = (mySED.wave >= 3000) & (mySED.wave <= 7000)
     for trest in np.linspace(-10, 40, 20):
 
-        mySED.setParVals_BAYESN(THETA1=-1.7, AV=0. , RV=3.1 , DELTAM=0. ,  TMAX=0.)
-        flux = mySED.fetchSED_BAYESN(trest, new_event=2)
+        mySED.setParVals(THETA1=-1.7, AV=0. , RV=3.1 , DELTAM=0. ,  TMAX=0.)
+        flux = mySED.fetchSED(trest, new_event=2)
         ax2.plot(mySED.wave[ind], np.array(flux)[ind]/np.array(flux)[ind].max() + trest, 'b-')
 
-        mySED.setParVals_BAYESN(THETA1=0., AV=0.1 , RV=3.1 , DELTAM=0. , TMAX=0.)
-        flux = mySED.fetchSED_BAYESN(trest, new_event=2)
+        mySED.setParVals(THETA1=0., AV=0.1 , RV=3.1 , DELTAM=0. , TMAX=0.)
+        flux = mySED.fetchSED(trest, new_event=2)
         ax2.plot(mySED.wave[ind], np.array(flux)[ind]/np.array(flux)[ind].max() + trest, 'g-')
 
-        mySED.setParVals_BAYESN(THETA1=2., AV=0.3 , RV=3.1 , DELTAM=0. , TMAX=0.)
-        flux = mySED.fetchSED_BAYESN(trest, new_event=2)
+        mySED.setParVals(THETA1=2., AV=0.3 , RV=3.1 , DELTAM=0. , TMAX=0.)
+        flux = mySED.fetchSED(trest, new_event=2)
         ax2.plot(mySED.wave[ind], np.array(flux)[ind]/np.array(flux)[ind].max() + trest, 'r-')
     fig2.savefig('phase_sequence.png')
 

--- a/src/gensed_BAYESN.py
+++ b/src/gensed_BAYESN.py
@@ -402,13 +402,6 @@ class gensed_BAYESN:
         return list(self.parameter_names)
 
 
-    def fetchNParNames_BAYESN(self):
-        """
-        Returns the number of model parameters
-        """
-        return len(self.parameter_names)
-
-
     def fetchParVals_BAYESN_4SNANA(self,varname):
         """
         Returns the value of parameter 'varname'

--- a/src/gensed_BAYESN.py
+++ b/src/gensed_BAYESN.py
@@ -273,18 +273,11 @@ class gensed_BAYESN:
         # end loop over parameters
 
 
-    def fetchSED_NLAM(self):
-        """
-        Returns the length of the wavelength vector
-        """
-        return self.wavelen
-
-
     def fetchSED_LAM(self):
         """
         Returns the wavelength vector
         """
-        return list(self.wave)
+        return np.asarray(self.wave)
 
 
     def fetchSED_BAYESN(self, trest, maxlam=5000, external_id=1, new_event=1, hostpars=''):
@@ -379,7 +372,7 @@ class gensed_BAYESN:
         flux = np.exp(-GAMMA*(self.M0 + self.parameter_values["DELTAM"]))*S_tilde
 
         ########## ORIGINAL RETURN STATEMENT FROM GSN ##########
-        return list(flux)
+        return np.asarray(flux)
 
 
     def setParVals_BAYESN(self, **kwargs):

--- a/src/gensed_BYOSED.py
+++ b/src/gensed_BYOSED.py
@@ -18,6 +18,8 @@ from scipy.stats import rv_continuous,gaussian_kde,norm as normal
 from copy import copy
 import pickle
 
+from gensed_base import gensed_base
+
 if not hasattr(sys, 'argv'):
 		sys.argv  = ['']
 
@@ -37,7 +39,7 @@ def print_err():
 	raise RuntimeError
 
 
-class gensed_BYOSED:
+class gensed_BYOSED(gensed_base):
 		def __init__(self,PATH_VERSION,OPTMASK,ARGLIST,HOST_PARAM_NAMES):
 			# TODO: write a print statement that warns if
 			# HOST_PARAM_NAMES is a variable that the code
@@ -99,7 +101,7 @@ class gensed_BYOSED:
 
 				self.warp_effects=self.fetchParNames_CONFIG(config)
 
-				self.sn_effects,self.host_effects=self.fetchWarp_BYOSED(config)
+				self.sn_effects,self.host_effects=self.fetchWarp(config)
 
 				phase,wave,flux = np.loadtxt(_append_path(self.PATH_VERSION,self.options.sed_file),unpack=True)
 
@@ -159,7 +161,7 @@ class gensed_BYOSED:
 				
 				
 		
-		def fetchWarp_BYOSED(self,config):
+		def fetchWarp(self,config):
 			#read in warp effect data
 
 			sn_dict=dict([])
@@ -245,10 +247,10 @@ class gensed_BYOSED:
 		
 				
 		def fetchSED_LAM(self):
-				return np.asarray(self.wave)
+				return self.wave
 		
 
-		def fetchSED_BYOSED(self,trest,maxlam=5000,external_id=1,new_event=1,hostpars=''):
+		def fetchSED(self,trest,maxlam=5000,external_id=1,new_event=1,hostpars=''):
 			try:
 				if len(self.wave)>maxlam:
 					raise RuntimeError("Your wavelength array cannot be larger than %i but is %i"%(maxlam,len(self.wave)))
@@ -261,7 +263,7 @@ class gensed_BYOSED:
 
 				self.sn_id=external_id
 				if not newSN and np.round(trest,6) in self.phase_data.keys():
-					return np.asarray(copy(self.phase_data[np.round(trest,6)]))
+					return copy(self.phase_data[np.round(trest,6)])
 
 				fluxsmear=np.array(self.sedInterp(trest,self.wave).flatten())
 				orig_fluxsmear=copy(fluxsmear)
@@ -367,7 +369,7 @@ class gensed_BYOSED:
 				fluxsmear*=self.brightness_correct_Ia()
 
 			self.phase_data[np.round(trest,6)]=list(fluxsmear)
-			return np.asarray(fluxsmear)
+			return fluxsmear
 			
 		def brightness_correct_Ia(self):
 			if 'COLOR' in self.sn_effects.keys():
@@ -381,10 +383,10 @@ class gensed_BYOSED:
 			return(10**(-.4*(self.beta*c-self.alpha*s)))
 
 		
-		def fetchParNames_BYOSED(self):
+		def fetchParNames(self):
 				return list(np.append(self.warp_effects,['lum']))
 
-		def fetchParVals_BYOSED_4SNANA(self,varname):
+		def fetchParVals(self,varname):
 				if varname=='lum':
 					return self.x0*(10**(-0.4*self.magsmear))
 				if varname in self.sn_effects.keys():
@@ -398,13 +400,7 @@ class gensed_BYOSED:
 						return self.host_effects[varname].warp_parameter
 					else:
 						return self.host_effects[varname].scale_parameter
-					
 
-		def fetchParVals_BYOSED(self,varname):
-				if varname in self.sn_effects.keys():
-					return self.sn_effects[varname].warp_parameter
-				else:
-					return self.host_effects[varname].warp_parameter
 		def fetchParNames_CONFIG(self,config):
 				if 'FLAGS' in config.sections():
 						return([k.upper() for k in list(config['FLAGS'].keys()) if config['FLAGS'][k]=='True'])
@@ -720,8 +716,8 @@ def main():
 
 		mySED=gensed_BYOSED('$SNDATA_ROOT/models/BYOSED/BYOSED.P21/',2,'','REDSHIFT,AGE,ZCMB,METALLICITY,HOSTMASS')
 		mySED.sn_id=1
-		print(np.sum(mySED.fetchSED_BYOSED(0,5000,0,0,[.1,1,1,.5,11])))
-		print(np.sum(mySED.fetchSED_BYOSED(-5,5000,0,1,[.1,1,1,.5,9])))
+		print(np.sum(mySED.fetchSED(0,5000,0,0,[.1,1,1,.5,11])))
+		print(np.sum(mySED.fetchSED(-5,5000,0,1,[.1,1,1,.5,9])))
 
 if __name__=='__main__':
 		main()

--- a/src/gensed_BYOSED.py
+++ b/src/gensed_BYOSED.py
@@ -244,11 +244,8 @@ class gensed_BYOSED:
 			return(sn_dict,host_dict)
 		
 				
-		def fetchSED_NLAM(self):
-				return self.wavelen
-
 		def fetchSED_LAM(self):
-				return list(self.wave)
+				return np.asarray(self.wave)
 		
 
 		def fetchSED_BYOSED(self,trest,maxlam=5000,external_id=1,new_event=1,hostpars=''):
@@ -264,7 +261,7 @@ class gensed_BYOSED:
 
 				self.sn_id=external_id
 				if not newSN and np.round(trest,6) in self.phase_data.keys():
-					return copy(self.phase_data[np.round(trest,6)])
+					return np.asarray(copy(self.phase_data[np.round(trest,6)]))
 
 				fluxsmear=np.array(self.sedInterp(trest,self.wave).flatten())
 				orig_fluxsmear=copy(fluxsmear)
@@ -370,7 +367,7 @@ class gensed_BYOSED:
 				fluxsmear*=self.brightness_correct_Ia()
 
 			self.phase_data[np.round(trest,6)]=list(fluxsmear)
-			return list(fluxsmear)
+			return np.asarray(fluxsmear)
 			
 		def brightness_correct_Ia(self):
 			if 'COLOR' in self.sn_effects.keys():

--- a/src/gensed_BYOSED.py
+++ b/src/gensed_BYOSED.py
@@ -387,9 +387,6 @@ class gensed_BYOSED:
 		def fetchParNames_BYOSED(self):
 				return list(np.append(self.warp_effects,['lum']))
 
-		def fetchNParNames_BYOSED(self):
-				return len(self.warp_effects)+1
-
 		def fetchParVals_BYOSED_4SNANA(self,varname):
 				if varname=='lum':
 					return self.x0*(10**(-0.4*self.magsmear))

--- a/src/gensed_SNEMO.py
+++ b/src/gensed_SNEMO.py
@@ -56,17 +56,11 @@ class gensed_SNEMO:
 			return
 		
 				
-		def fetchSED_NLAM(self):
-			"""
-			Returns the length of the wavelength vector
-			"""
-			return self.wavelen
-
 		def fetchSED_LAM(self):
 			"""
 			Returns the wavelength vector
 			"""
-			return list(self.wave)
+			return np.asarray(self.wave)
 		
 		def fetchSED_SNEMO(self,trest,maxlam=5000,external_id=1,new_event=1,hostpars=''):
 			"""

--- a/src/gensed_SNEMO.py
+++ b/src/gensed_SNEMO.py
@@ -2,6 +2,8 @@ import sys
 import os
 import yaml
 
+from gensed_base import gensed_base
+
 mask_bit_locations = {'verbose':1,'dump':2}
 
 def print_err():
@@ -16,7 +18,7 @@ def print_err():
 	raise RuntimeError
 
 
-class gensed_SNEMO:
+class gensed_SNEMO(gensed_base):
 		def __init__(self,PATH_VERSION,OPTMASK,ARGLIST,HOST_PARAM_NAMES):
 			try:
 				self.verbose = OPTMASK & (1 << mask_bit_locations['verbose']) > 0
@@ -60,9 +62,9 @@ class gensed_SNEMO:
 			"""
 			Returns the wavelength vector
 			"""
-			return np.asarray(self.wave)
+			return self.wave
 		
-		def fetchSED_SNEMO(self,trest,maxlam=5000,external_id=1,new_event=1,hostpars=''):
+		def fetchSED(self,trest,maxlam=5000,external_id=1,new_event=1,hostpars=''):
 			"""
 			Returns the flux at every wavelength, for a given phase.
 			
@@ -103,13 +105,13 @@ class gensed_SNEMO:
 			
 
 		
-		def fetchParNames_SNEMO(self):
+		def fetchParNames(self):
 			"""
 			Returns the names of model parameters
 			"""
 			return list(self.parameter_names)
 
-		def fetchParVals_SNEMO_4SNANA(self,varname):
+		def fetchParVals(self,varname):
 			"""
 			Returns the value of parameter 'varname'
 			

--- a/src/gensed_SNEMO.py
+++ b/src/gensed_SNEMO.py
@@ -115,12 +115,6 @@ class gensed_SNEMO:
 			"""
 			return list(self.parameter_names)
 
-		def fetchNParNames_SNEMO(self):
-			"""
-			Returns the number of model parameters
-			"""
-			return len(self.self.parameter_names)
-
 		def fetchParVals_SNEMO_4SNANA(self,varname):
 			"""
 			Returns the value of parameter 'varname'

--- a/src/gensed_base.py
+++ b/src/gensed_base.py
@@ -1,0 +1,74 @@
+from abc import ABC, abstractmethod
+from typing import Sequence, Tuple
+
+import numpy as np
+import numpy.typing as npt
+
+
+class gensed_base(ABC):
+    @abstractmethod
+    def __init__(self, PATH_VERSION: str, OPTMASK: int, ARGLIST: str, HOST_PARAM_NAMES: str):
+        pass
+
+
+    @abstractmethod
+    def fetchSED_LAM(self) -> npt.ArrayLike:
+        """
+        Numpy array of dtype float64 with wavelengths in Angstrom
+        """
+        raise NotImplementedError
+
+    def _fetchSED_LAM(self) -> np.ndarray:
+        """Wrapper of fetchSED_LAM to call from C"""
+        return np.asarray(self.fetchSED_LAM(), dtype=np.float64)
+
+    @abstractmethod
+    def fetchSED(self, trest: float, maxlam: int, external_id: int, new_event: int, hostpars: Tuple[float]) -> npt.ArrayLike:
+        """
+        Returns the flux at every wavelength, for a given phase.
+
+        Parameters
+        ----------
+        trest : float
+             The rest frame phase at which to calculate the flux
+        maxlam : int
+             A maximum number of wavelength bins. If your wavelength
+             vector is longer than this number (default is arbitrary),
+             program should abort
+        external_id : int
+             ID for SN
+        new_event : int
+             1 if new event, 0 if same SN
+        hostpars : tuple[float]
+             Host parameters corresponded to HOST_PARAM_NAMES
+
+        Returns
+        -------
+        A numpy array of dtype float64 the same length as fetchSED_LAM containing the flux
+        observed from 10 pc in erg / s / cm^2 / Angstrom
+        """
+        raise NotImplementedError
+
+    def _fetchSED(self, *args, **kwargs) -> np.ndarray:
+        """Wrapper of fetchSED to call from C"""
+        return np.asarray(self.fetchSED(*args, **kwargs), dtype=np.float64)
+
+    @abstractmethod
+    def fetchParNames(self) -> Sequence[str]:
+        """
+        Returns the names of model parameters
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def fetchParVals(self, varname: str) -> float:
+        """
+        Returns the value of parameter 'varname'
+
+        Parameters
+        ----------
+        varname : str
+             A parameter name from self.parameter_names
+        """
+        raise NotImplementedError
+


### PR DESCRIPTION
- [x] Remove `fetchSED_NLAM` and `fetchNParNames_{PYSED_MODEL}` methods
- [x] Consider return value of `fetchParNames_{PYSED_MODEL}` as sequence and check it. Previously unsafe type casting to list was performed
- [x] Exception handling
- [x] Check more return values from Python C API functions
- [x] Change return type of `fetchSED_{PYSED_MODEL}` and `fetchSED_LAM` to numpy array and use buffer protocol of Python C API to copy fetched values efficiently
- [x] Replace deprecated `PyEval_CallObject` with `PyObject_CallObject`
- [x] Change Python types for some C-int variables like `EXTERNAL_ID ` and `MXLAM`
- [x] Abstract class for all the models and remove `_{PYSED_MODEL}` suffix from methods
- [x] Tests have been run