### PR TITLE
AGN pySED model

### DIFF
--- a/src/genmag_PySEDMODEL.c
+++ b/src/genmag_PySEDMODEL.c
@@ -69,6 +69,8 @@
 #include  <Python.h>
 //#include <numpy/arrayobject.h>
 //#include <numpy/ndarrayobject.h>
+PyObject *numpy_empty, *numpy_double; // numpy.empty, numpy.double
+
 PyObject *geninit_PySEDMODEL ;
 
 //int init_numpy(){
@@ -243,6 +245,13 @@ void init_genmag_PySEDMODEL(char *MODEL_NAME, char *PATH_VERSION, int OPTMASK,
     errmsg(SEV_FATAL, 0, fnam, c1err, c2err);
   }
 
+  // Get numpy empty, we will reuse it
+  PyObject *numpy = PyImport_ImportModule("numpy");
+  numpy_empty = PyObject_GetAttrString(numpy, "empty");
+  numpy_double = PyObject_GetAttrString(numpy, "double");
+  handle_python_exception(fnam, "importing numpy and getting numpy.empty & numpy.double");
+  Py_DECREF(numpy);
+
   printf("DEBUG", PyCLASS_NAME, "\n");
   genmod_base = PyImport_ImportModule("gensed_base");
   if (genmod_base == NULL) {
@@ -348,10 +357,9 @@ void get_MODEL_NAME_PySEDMODEL(char *PATH,char *MODEL_NAME) {
 
 
 // =========================================================
-void prepEvent_PySEDMODEL(int CID, double zCMB, 
+void prepEvent_PySEDMODEL(int EXTERNAL_ID, double zHEL,
 			  int NHOSTPAR, double *HOSTPAR_LIST,
 			  int NOBS, double *TOBS_LIST ) {
-
   // Created Sep 2022 by R.Kessler
   // Interface to prepare seds for all epochs (over all bands),
   // instead of genmag_PySEDMODEL that is called for each band.
@@ -363,55 +371,91 @@ void prepEvent_PySEDMODEL(int CID, double zCMB,
   // and thus cannot processed by band.
   //
   // Inputs:
-  //   CID  integer id for event
-  //   zCMB  : CMB redshift (to allow for z-dependent model)
+  //   EXTERNAL_ID  :  SNID passed from main program
+  //   zHEL  : heliocentric redshift (to allow for z-dependent model)
   //  NHOSTPAR:      number of host params
   //  HOSTPAR_LIST:  host property values
   //  NOBS:          total number of observations, all bands
   //  TOBS_LIST:     observer-frame times w.r.t. PEAKMJD
   //
 
+  #ifdef USE_PYTHON
+  
   char *MODEL_NAME   = INPUTS_PySEDMODEL.MODEL_NAME ;
-  int MEMD           = (NOBS+10) * sizeof(double);
   int MEMI           = (NOBS+10) * sizeof(int);
-  double *Trest_list = (double*)malloc(MEMD);
   int    *INDEX_SORT = (int*)   malloc(MEMI);
-  double z1      = 1.0 + zCMB;
+  double *arrTrest;
+  double z1      = 1.0 + zHEL;
   double z1inv   = 1.0/z1;
-  double Tobs_template ;
-  int o, o_sort, NOBS_STORE=0;
+  double Tobs_template;
+  int o, o_sort, i, ihost, NOBS_STORE;
   char fnam[] = "prepEvent_PySEDMODEL";
+  
+  PyObject *pHOSTPARS, *pTrest, *prepmeth;
+  Py_buffer bufTrest = {NULL, NULL};
 
   // ------------- BEGIN ------------
 
+
   // sort TOBS_LIST in increasing order
   int ORDER_SORT = +1; // ==> increasing
-  sortDouble(NOBS, TOBS_LIST, ORDER_SORT, INDEX_SORT );
+  sortDouble(NOBS, TOBS_LIST, ORDER_SORT, INDEX_SORT);
 
-  // for recurring model (e.g., AGN), pick arbitrary 
-  // DIA template time 1 year earlier
+  // for recurring models (e.g., AGN), we need one extra DIA tempalte
   bool RECUR = ( strcmp(MODEL_NAME,MODEL_NAME_AGN) == 0 );
+  
   if ( RECUR ) {
-    Tobs_template = TOBS_LIST[0] - 365.0 ;
-    Trest_list[NOBS_STORE] = Tobs_template * z1inv ;
-    NOBS_STORE++ ;
-  }
-  else {
+    o_sort = INDEX_SORT[0];
+    Tobs_template = TOBS_LIST[o_sort] - 365.0 ; // arbitrary value of one year
+    NOBS_STORE = NOBS + 1;
+  } else {
     Tobs_template = -1.0E8; // not used
+    NOBS_STORE = NOBS;
   }
-
-  for(o=0; o < NOBS; o++ )  { 
-    o_sort = INDEX_SORT[o] ;
-    Trest_list[NOBS_STORE] = TOBS_LIST[o_sort] * z1inv ; 
-    NOBS_STORE++ ;
-  }
-
   Event_PySEDMODEL.Tobs_template = Tobs_template ;
 
-  // call python here ...
+  // Creating an empty numpy array to handle Trest
+  // It would be more clear to use numpy C-API, but we wouldn't introduce numpy
+  // as a build dependency.
+  pTrest = PyObject_CallFunction(numpy_empty, "(iO)", NOBS_STORE, numpy_double);
+  handle_python_exception(fnam, "creating ndarray for trest");
+  if (PyObject_GetBuffer(pTrest, &bufTrest, PyBUF_CONTIG) != 0) {
+    sprintf(c1err,"pTrest must be a contiguous numpy array");
+    sprintf(c2err,"??");
+    errmsg(SEV_FATAL, 0, fnam, c1err, c2err);
+  }
+  arrTrest = (double*) bufTrest.buf;
 
+  if ( RECUR ) {
+    arrTrest[0] = Tobs_template * z1inv;
+  }
+  for(o=0; o < NOBS; o++ )  { 
+    o_sort = INDEX_SORT[o];
+    i = o + (int) RECUR;
+    arrTrest[i] = TOBS_LIST[o_sort] * z1inv ;
+  }
 
-  free(Trest_list);
+  // Give Python model Trest array so it is prepared
+  // for fetching Trest in an arbitrary order
+  prepmeth = PyObject_GetAttrString(geninit_PySEDMODEL, "prepEvent");
+  handle_python_exception(fnam, "getting prepEvent method");
+  
+  pHOSTPARS = PyTuple_New(NHOSTPAR);
+  for(ihost=0; ihost < NHOSTPAR; ihost++ ){
+    PyTuple_SetItem(pHOSTPARS,ihost,PyFloat_FromDouble(HOSTPAR_LIST[ihost]));
+  }
+
+  PyObject_CallFunction(prepmeth, "(OiO)", pTrest, EXTERNAL_ID, pHOSTPARS);
+  handle_python_exception(fnam, "calling prepEvent");
+
+  PyBuffer_Release(&bufTrest);
+  Py_DECREF(pHOSTPARS);
+  Py_DECREF(pTrest);
+  Py_DECREF(prepmeth);
+
+  free(INDEX_SORT);
+
+  #endif
   return;
 
 } // end prepEvent_PySEDMODEL
@@ -454,6 +498,7 @@ void genmag_PySEDMODEL(int EXTERNAL_ID, double zHEL, double zCMB, double MU,
   double RV_host = HOSTPAR_LIST[0];
   double AV_host = HOSTPAR_LIST[1];
   double z1    = 1.0 + zHEL ;
+  double z1inv   = 1.0/z1;
   double *LAM  = Event_PySEDMODEL.LAM;
   double *SED  = Event_PySEDMODEL.SED ;
   bool DO_TEMPLATE = Event_PySEDMODEL.Tobs_template > -1.0E7 ;
@@ -468,7 +513,6 @@ void genmag_PySEDMODEL(int EXTERNAL_ID, double zHEL, double zCMB, double MU,
 
   int    NLAM, o, ipar ;
   double Tobs, Trest, FLUXSUM_OBS, FspecDUM[2], magobs ;
-  char   pyFORMAT_STRING_HOSTPAR[100] ;;
   char fnam[] = "genmag_PySEDMODEL" ;
 
    #ifdef USE_PYTHON
@@ -502,18 +546,6 @@ void genmag_PySEDMODEL(int EXTERNAL_ID, double zHEL, double zCMB, double MU,
     fflush(stdout);
   }
 
-  // construct hostpar string to pass to python
-  sprintf(pyFORMAT_STRING_HOSTPAR,"diii[" );
-  for(ipar=0; ipar < NHOSTPAR; ipar++ ) {
-    strcat(pyFORMAT_STRING_HOSTPAR,"d");
-    if ( ipar < NHOSTPAR-1 )
-      { strcat(pyFORMAT_STRING_HOSTPAR,","); }
-    else
-      { strcat(pyFORMAT_STRING_HOSTPAR,"]"); }
-  }
-  //  printf(" xxx pySTRING_HOSTPAR = '%s' \n", pyFORMAT_STRING_HOSTPAR );
-
-
   /*
   printf(" xxx ------------------------------------ \n" ) ;
   printf(" xxx %s: process z=%.3f MU=%.3f RV=%3.1f IFILT_OBS=%d(%s) \n",
@@ -537,15 +569,14 @@ void genmag_PySEDMODEL(int EXTERNAL_ID, double zHEL, double zCMB, double MU,
     else
       { Tobs =  Event_PySEDMODEL.Tobs_template; }
 
-    Trest = Tobs/z1;
+    Trest = Tobs * z1inv;
     if (o == 0 )
       { NEWEVT_FLAG_TMP = NEWEVT_FLAG; }
     else
       { NEWEVT_FLAG_TMP = 0; }
 
     fetchSED_PySEDMODEL(EXTERNAL_ID, NEWEVT_FLAG_TMP, Trest,
-			MXLAM, HOSTPAR_LIST, &NLAM, LAM, SED,
-			pyFORMAT_STRING_HOSTPAR);
+			MXLAM, HOSTPAR_LIST, &NLAM, LAM, SED);
     Event_PySEDMODEL.NLAM = NLAM ;
 
     // integrate redshifted SED to get observer-frame flux in IFILT_OBS band.
@@ -706,8 +737,7 @@ void fetchParVal_PySEDMODEL(double *parVal) {
 // =================================================
 void fetchSED_PySEDMODEL(int EXTERNAL_ID, int NEWEVT_FLAG, double Trest, int MXLAM,
 			 double *HOSTPAR_LIST, int *NLAM_SED,
-			 double *LAM_SED, double *FLUX_SED,
-			 char *pyFORMAT_STRING_HOSTPAR) {
+			 double *LAM_SED, double *FLUX_SED) {
 
   // return rest-frame SED to calling function;
   // Inputs:
@@ -733,8 +763,8 @@ void fetchSED_PySEDMODEL(int EXTERNAL_ID, int NEWEVT_FLAG, double Trest, int MXL
 
 #ifdef USE_PYTHON
   PyObject *pmeth, *pargs, *pargs2, *pLAM, *pFLUX, *plammeth;
-  Py_buffer viewLAM = {NULL, NULL};
-  Py_buffer viewFLUX = {NULL, NULL};
+  Py_buffer bufLAM = {NULL, NULL};
+  Py_buffer bufFLUX = {NULL, NULL};
   int NLAM, ilam, ihost;
   //int numpy_initialized =  init_numpy();
 
@@ -774,39 +804,39 @@ void fetchSED_PySEDMODEL(int EXTERNAL_ID, int NEWEVT_FLAG, double Trest, int MXL
     errmsg(SEV_FATAL, 0, fnam, c1err, c2err);
   };
 
-  if (PyObject_GetBuffer(pLAM, &viewLAM, PyBUF_FULL_RO) != 0) {
+  if (PyObject_GetBuffer(pLAM, &bufLAM, PyBUF_FULL_RO) != 0) {
     handle_python_exception(fnam, "setting buffer from pLAM");
   }
-  if (PyObject_GetBuffer(pFLUX, &viewFLUX, PyBUF_FULL_RO) != 0) {
+  if (PyObject_GetBuffer(pFLUX, &bufFLUX, PyBUF_FULL_RO) != 0) {
     handle_python_exception(fnam, "setting buffer from pFLUX");
   }
 
-  if (viewLAM.itemsize != sizeof(double)) {
+  if (bufLAM.itemsize != sizeof(double)) {
     sprintf(c1err,"_fetchSED_LAM must return numpy array with np.float64 dtype");
-    sprintf(c2err,"itemsize of returned dtype is %d",viewLAM.itemsize);
+    sprintf(c2err,"itemsize of returned dtype is %d",bufLAM.itemsize);
     errmsg(SEV_FATAL, 0, fnam, c1err, c2err);
   }
 
-  if (viewFLUX.itemsize != sizeof(double)) {
+  if (bufFLUX.itemsize != sizeof(double)) {
     sprintf(c1err,"_fetchSED must return numpy array with np.float64 dtype");
-    sprintf(c2err,"itemsize of returned dtype is %d",viewFLUX.itemsize);
+    sprintf(c2err,"itemsize of returned dtype is %d",bufFLUX.itemsize);
     errmsg(SEV_FATAL, 0, fnam, c1err, c2err);
   }
 
-  NLAM = viewLAM.len / viewLAM.itemsize;
-  if (NLAM != viewFLUX.len / viewFLUX.itemsize) {
+  NLAM = bufLAM.len / bufLAM.itemsize;
+  if (NLAM != bufFLUX.len / bufFLUX.itemsize) {
     sprintf(c1err,"size of array returned by _fetchSED_LAM doesn't equal to one returned by _fetchSED");
-    sprintf(c2err,"NLAM = %d, NFLUX = %d",viewLAM.len / viewLAM.itemsize, viewFLUX.len / viewFLUX.itemsize);
+    sprintf(c2err,"NLAM = %d, NFLUX = %d",bufLAM.len / bufLAM.itemsize, bufFLUX.len / bufFLUX.itemsize);
     errmsg(SEV_FATAL, 0, fnam, c1err, c2err);
   }
 
-  PyBuffer_ToContiguous(LAM_SED, &viewLAM, viewLAM.len, 'C');
-  PyBuffer_ToContiguous(FLUX_SED, &viewFLUX, viewFLUX.len, 'C');
+  PyBuffer_ToContiguous(LAM_SED, &bufLAM, bufLAM.len, 'C');
+  PyBuffer_ToContiguous(FLUX_SED, &bufFLUX, bufFLUX.len, 'C');
 
   *NLAM_SED = NLAM;
 
-  PyBuffer_Release(&viewLAM);
-  PyBuffer_Release(&viewFLUX);
+  PyBuffer_Release(&bufLAM);
+  PyBuffer_Release(&bufFLUX);
   Py_DECREF(pLAM);
   Py_DECREF(pFLUX);
   Py_DECREF(pargs);
@@ -1078,7 +1108,6 @@ void genSpec_PySEDMODEL(double Tobs, double zHEL, double MU,
   int NBLAM    = SPECTROGRAPH_SEDMODEL.NBLAM_TOT ;
   int ilam, NLAM, FLAG_ignore ;
   int    NEWEVT_FLAG = 0 ;
-  char   pyFORMAT_STRING_HOSTPAR[100] ;;
   double Finteg_ignore, FTMP, MAG, ZP, LAM, Trest ;
   double *SED   = Event_PySEDMODEL.SED ;
   double *FLAM  = Event_PySEDMODEL.LAM;
@@ -1091,8 +1120,7 @@ void genSpec_PySEDMODEL(double Tobs, double zHEL, double MU,
   // get the spectrum
   Trest = Tobs/z1;
   fetchSED_PySEDMODEL(Event_PySEDMODEL.EXTERNAL_ID, NEWEVT_FLAG, Trest,
-		      MXLAM_PySEDMODEL, HOSTPAR_LIST, &NLAM, FLAM, SED,
-		      pyFORMAT_STRING_HOSTPAR);
+		      MXLAM_PySEDMODEL, HOSTPAR_LIST, &NLAM, FLAM, SED);
   Event_PySEDMODEL.NLAM = NLAM ;
 
 

--- a/src/genmag_PySEDMODEL.c
+++ b/src/genmag_PySEDMODEL.c
@@ -10,6 +10,7 @@
      gensed_BYOSED.py : Build Your Own SED  (J.Pierel)
      gensed_SNEMO.py  : SNFactory model (Ben Rose)
      gensed_BAYESN.py : BayeSN model (Gautham Narayan, Stephen Thorp, Kaisey Mandel)
+     gensed_AGN.py : AGN model (Qifeng Cheng, Konstantin Malanchev)
 
   Initial motivation is to build underlying "true" SED model to
   test SNIa model training. However, this function could in

--- a/src/genmag_PySEDMODEL.h
+++ b/src/genmag_PySEDMODEL.h
@@ -57,7 +57,7 @@ void init_genmag_PySEDMODEL(char *MODEL_NAME, char *PATH_VERSION,
 
 void get_MODEL_NAME_PySEDMODEL(char *PATH,char *MODEL_NAME);
 
-void prepEvent_PySEDMODEL(int CID, double zCMB, 
+void prepEvent_PySEDMODEL(int EXTERNAL_ID, double zCMB, 
 			  int NHOSTPAR, double *HOSTPAR_LIST,
                           int NOBS_ALL, double *TOBS_LIST);
 
@@ -71,8 +71,7 @@ int  fetchParNames_PySEDMODEL(char **parNameList);
 void fetchParVal_PySEDMODEL(double *parVal);
 void fetchSED_PySEDMODEL(int EXTERNAL_ID, int NEWEVT_FLAG, double Tobs,
 			 int MXLAM, double *HOSTPAR_LIST, int *NLAM,
-			 double *LAM, double *FLUX,
-			 char *pyFORMAT_STRING_HOSTPAR);
+			 double *LAM, double *FLUX);
 
 void INTEG_zSED_PySEDMODEL(int OPT_SPEC, int IFILT_OBS, double Tobs,
 			   double zHEL, double x0,

--- a/src/gensed_AGN.py
+++ b/src/gensed_AGN.py
@@ -1,0 +1,121 @@
+import numpy as np
+from astropy import constants
+from astropy.cosmology import Planck18
+
+M_sun = constants.M_sun.cgs.value
+c = constants.c.cgs.value
+
+
+class AGN:
+    def __init__(self, t0: float, Mi: float, M_BH: float, lam: np.ndarray, rng):  # constructor
+        self.lam = np.asarray(lam)
+        self.t0 = t0
+        self.rng = np.random.default_rng(rng)
+
+        self.Fnu_average = self.find_Fnu_average(self.lam, M_BH, None)
+
+        self.tau = self.find_tau_v(self.lam, Mi, M_BH)
+        self.sf_inf = self.find_sf_inf(self.lam, Mi, M_BH)
+
+        self.t = t0
+        self.delta_m = self._random() * self.sf_inf
+
+    def step(self, t):
+        dt = t - self.t
+
+        self.t = t
+
+        self.delta_m = (
+                self.delta_m * np.exp(-dt / self.tau)
+                + self.sf_inf * np.sqrt(1 - np.exp(-2 * dt / self.tau)) * self._random()
+        )
+
+    def __call__(self, t):
+        self.step(t)
+        return self.Fnu
+
+    @property
+    def Fnu(self):
+        return 10 ** (-0.4 * self.delta_m) * self.Fnu_average
+
+    def _random(self):
+        return self.rng.normal(size=self.lam.size)
+
+    @staticmethod
+    def find_Fnu_average(lam, M_BH, eddington_ratio):
+        # Input wavelength as array.
+        # Return baseline (average value).
+
+        z = 0.2
+        mu = Planck18.distmod(z).value
+        F_av = 10 ** (-0.4 * (20 + 48.6 - mu))
+        Fnu_ave = np.full_like(lam, F_av)
+        return Fnu_ave
+        # return 1e-29 * (lam / 5000e-8)**(-1/3)
+
+    @staticmethod
+    def find_tau_v(lam, Mi=-23, M_BH=1e9 * M_sun):
+        """Input frequency v in Hz, i band magnitude (default is -23), Black whole mass in g (defalt is 10^9 solar mass).
+        Return timescale in s."""
+
+        A = 2.4  # self.rng.normal(2.4, ...)
+        B = 0.17
+        C = 0.03
+        D = 0.21
+        # add C, D, BH_mass, Mi
+        return 10 ** (A + B * np.log10(lam / (4000e-8))
+                      + C * (Mi + 23) + D * np.log10(M_BH / (1e9 * M_sun)))  # e-8 angstrom
+
+    @staticmethod
+    def find_sf_inf(lam, Mi=-23, M_BH=1e9 * M_sun):
+        """Input frequency in Hz, i band magnitude (default is -23), Black whole mass in g (defalt is 10^9 solar mass).
+
+        Return Structure Function at infinity in mag."""
+
+        A = -0.51
+        B = -0.479
+        C = 0.13
+        D = 0.18
+
+        return 10 ** (A + B * np.log10(lam / (4000e-8))
+                      + C * (Mi + 23) + D * np.log10(M_BH / (1e9 * M_sun)))
+
+
+class gensed_BAYESN:
+    def __init__(self, PATH_VERSION, OPTMASK, ARGLIST, HOST_PARAM_NAMES):
+        self.agn = None
+        self.rng = np.random.default_rng(0)
+        self.wavelen = 100
+        self.wave = np.logspace(np.log10(100e-8), np.log10(20000e-8), self.wavelen)
+
+    def fetchSED_NLAM(self):
+        """
+        Returns the length of the wavelength vector
+        """
+        return self.wavelen
+
+    def fetchSED_LAM(self):
+        """
+        Returns the wavelength vector
+        """
+        wave_aa = self.wave * 1e8
+        # print('wave:',wave_aa)
+        return wave_aa.tolist()
+
+    def fetchSED_BAYESN(self, trest, maxlam=5000, external_id=1, new_event=1, hostparams=''):
+        if new_event:
+            self.agn = AGN(t0=trest, Mi=-23, M_BH=1e9 * M_sun, lam=self.wave, rng=self.rng)
+        else:
+            self.agn.step(trest)
+        Flambda = self.agn.Fnu * c / self.wave ** 2 * 1e-8
+        return Flambda.tolist()
+
+    def fetchParNames_BAYESN(self):
+        return []
+
+    def fetchNParNames_BAYESN(self):
+        return 0
+
+    def fetchParVals_BAYESN_4SNANA(self, varname):
+        return 'SNANA'
+

--- a/src/gensed_AGN.py
+++ b/src/gensed_AGN.py
@@ -2,6 +2,9 @@ import numpy as np
 from astropy import constants
 from astropy.cosmology import Planck18
 
+from gensed_base import gensed_base
+
+
 M_sun = constants.M_sun.cgs.value
 c = constants.c.cgs.value
 
@@ -81,18 +84,12 @@ class AGN:
                       + C * (Mi + 23) + D * np.log10(M_BH / (1e9 * M_sun)))
 
 
-class gensed_BAYESN:
+class gensed_AGN(gensed_base):
     def __init__(self, PATH_VERSION, OPTMASK, ARGLIST, HOST_PARAM_NAMES):
         self.agn = None
         self.rng = np.random.default_rng(0)
         self.wavelen = 100
         self.wave = np.logspace(np.log10(100e-8), np.log10(20000e-8), self.wavelen)
-
-    def fetchSED_NLAM(self):
-        """
-        Returns the length of the wavelength vector
-        """
-        return self.wavelen
 
     def fetchSED_LAM(self):
         """
@@ -102,7 +99,7 @@ class gensed_BAYESN:
         # print('wave:',wave_aa)
         return wave_aa.tolist()
 
-    def fetchSED_BAYESN(self, trest, maxlam=5000, external_id=1, new_event=1, hostparams=''):
+    def fetchSED(self, trest, maxlam=5000, external_id=1, new_event=1, hostparams=''):
         if new_event:
             self.agn = AGN(t0=trest, Mi=-23, M_BH=1e9 * M_sun, lam=self.wave, rng=self.rng)
         else:
@@ -110,12 +107,9 @@ class gensed_BAYESN:
         Flambda = self.agn.Fnu * c / self.wave ** 2 * 1e-8
         return Flambda.tolist()
 
-    def fetchParNames_BAYESN(self):
+    def fetchParNames(self):
         return []
 
-    def fetchNParNames_BAYESN(self):
-        return 0
-
-    def fetchParVals_BAYESN_4SNANA(self, varname):
+    def fetchParVals(self, varname):
         return 'SNANA'
 

--- a/src/gensed_base.py
+++ b/src/gensed_base.py
@@ -10,6 +10,25 @@ class gensed_base(ABC):
     def __init__(self, PATH_VERSION: str, OPTMASK: int, ARGLIST: str, HOST_PARAM_NAMES: str):
         pass
 
+    def prepEvent(self, trest: np.ndarray, external_id: int, hostpars: Tuple[float]) -> None:
+        """
+        Prepare model before self.fetchSED(new_event=1) is called
+
+        This method is made non-abstract intentionally, it is optional to
+        implement and required only for models (e.g. AGN) which need to
+        prepare SEDs for all Trest in advance
+
+        Parameters
+        ----------
+        trest : ndarray[float64]
+            The rest frame phases at which to calculate the flux. It is sorted
+            in the ascending order
+        external_id : int
+             ID for event
+        hostpars : tuple[float]
+             Host parameters corresponded to HOST_PARAM_NAMES
+        """
+        pass
 
     @abstractmethod
     def fetchSED_LAM(self) -> npt.ArrayLike:
@@ -36,9 +55,9 @@ class gensed_base(ABC):
              vector is longer than this number (default is arbitrary),
              program should abort
         external_id : int
-             ID for SN
+             ID for event
         new_event : int
-             1 if new event, 0 if same SN
+             1 if new event, 0 if same event
         hostpars : tuple[float]
              Host parameters corresponded to HOST_PARAM_NAMES
 

--- a/src/snlc_sim.c
+++ b/src/snlc_sim.c
@@ -4107,7 +4107,7 @@ int parse_input_GENMODEL(char **WORDS, int keySource) {
   }
 
   // - - - - - - - - - - - - - - - - - - -
-  // check python models: BYOSED, SNEMO, BAYESN
+  // check python models: BYOSED, SNEMO, BAYESN, AGN
   NAME0 = GENMODEL_NAME[MODEL_BYOSED][0];
   if ( strcmp(GENMODEL,NAME0)==0 ) {
     N++ ; sscanf(WORDS[N], "%s", INPUTS.MODELPATH );
@@ -4121,6 +4121,12 @@ int parse_input_GENMODEL(char **WORDS, int keySource) {
   }
 
   NAME0 = GENMODEL_NAME[MODEL_BAYESN][0];  // Nov 2021
+  if ( strcmp(GENMODEL,NAME0)==0 ) {
+    N++ ; sscanf(WORDS[N], "%s", INPUTS.MODELPATH ); 
+    IS_PySEDMODEL = true;
+  }
+
+  NAME0 = GENMODEL_NAME[MODEL_AGN][0];  // Sep 2022
   if ( strcmp(GENMODEL,NAME0)==0 ) {
     N++ ; sscanf(WORDS[N], "%s", INPUTS.MODELPATH ); 
     IS_PySEDMODEL = true;
@@ -8191,6 +8197,8 @@ void  set_GENMODEL_NAME(void) {
   sprintf(GENMODEL_NAME[MODEL_SNEMO][0],   "%s", "SNEMO"   ); // pyModel
 
   sprintf(GENMODEL_NAME[MODEL_BAYESN][0],  "%s", "BAYESN"   ); // pyModel
+
+  sprintf(GENMODEL_NAME[MODEL_AGN][0],  "%s", "AGN"   ); // pyModel
 
   sprintf(GENMODEL_NAME[MODEL_SIMSED][0],  "%s", "SIMSED"  );
 
@@ -25407,7 +25415,7 @@ void genmodel(
 
   else if ( IS_PySEDMODEL ) {
 
-    // python-based SED model: BYOSED, SNEMO, BAYESN
+    // python-based SED model: BYOSED, SNEMO, BAYESN, AGN
     int NHOSTPAR; char *NAMES_HOSTPAR = NULL; 
     double VAL_HOSTPAR[MXHOSTPAR_PySEDMODEL];
     NHOSTPAR = fetch_HOSTPAR_GENMODEL(2, NAMES_HOSTPAR, VAL_HOSTPAR);

--- a/src/snlc_sim.c
+++ b/src/snlc_sim.c
@@ -25422,7 +25422,7 @@ void genmodel(
 
     // Sep 2022: optional sed prep for all MJDs on first call
     if ( ncall == 1 ) {
-      prepEvent_PySEDMODEL(GENLC.CID, GENLC.REDSHIFT_CMB,
+      prepEvent_PySEDMODEL(GENLC.CID, GENLC.REDSHIFT_HELIO,
 			   NHOSTPAR, VAL_HOSTPAR, 
 			   GENLC.NEPOCH, &GENLC.epoch_obs[1] );
     }

--- a/src/sntools.h
+++ b/src/sntools.h
@@ -153,6 +153,7 @@
 #define MODEL_BYOSED   8  // build-your-own SED model
 #define MODEL_SNEMO    9  // SNEMO from SNFactory (Sep 2020)
 #define MODEL_BAYESN    13  // BayeSN (Nov 2021)
+#define MODEL_AGN       14  // AGN (Sep 2022)
 #define MODEL_NON1ASED   10  // obs-frame NONIA from SED
 #define MODEL_NON1AGRID  11  // obs-frame NONIA from mag-grid (Mar 2016)
 #define MODEL_LCLIB      12  // light curve library (July 2017)


### PR DESCRIPTION
- Add `gensed_AGN.py` recurrent Python SED model
- Call `prepEvent()` Python method from C `prepEvent_PySEDMODEL()` function.
- Remove unused `pyFORMAT_STRING_HOSTPAR` variable

In `prepEvent_PySEDMODEL()` we use Python calls to create `Trest` numpy array. This could be done in a more convenient way using numpy C API, but I wouldn't like to introduce numpy as an SNANA build dependency.

I can imagine several performance tricks we can use to reduce unused computations:
1. We can mark (on a Python or C side) that a model requires event preparation and do not call `prepEvent_PySEDMODEL()` for models which don't need it. I would prefer to do it on a Python side, for example adding a class mixture `gensed_prepEvent` and inherit this class by models which need `prepEvent()`.
2. I'm not sure if it is a performance problem, but we recreate Python tuple with host parameters each time we call `fetchSED_PySEDMODEL()`, while we require to do it once per event only.