### PR TITLE
Fix undefined Event_PySEDMODEL.Tobs_template

### DIFF
--- a/src/genmag_PySEDMODEL.c
+++ b/src/genmag_PySEDMODEL.c
@@ -455,7 +455,11 @@ void prepEvent_PySEDMODEL(int EXTERNAL_ID, double zHEL,
 
   free(INDEX_SORT);
 
+  #else
+  // We don't need to do a template for SALT2
+  Event_PySEDMODEL.Tobs_template = -1.0E8;
   #endif
+
   return;
 
 } // end prepEvent_PySEDMODEL


### PR DESCRIPTION
`prepEvent_PySEDMODEL()` hasn't initialized `Event_PySEDMODEL.Tobs_template` for the case of undefined macro variable USE_PYTHON. This fixes regression introduced in commit 28ef6141994b1f5004c66185a75d19258d2ebc86