### PR TITLE
More Py SED models runtime checks

### DIFF
--- a/src/genmag_PySEDMODEL.c
+++ b/src/genmag_PySEDMODEL.c
@@ -712,12 +712,11 @@ void fetchParVal_PySEDMODEL(double *parVal) {
 #ifdef USE_PYTHON
 
   parvalmeth  = PyObject_GetAttrString(geninit_PySEDMODEL, "fetchParVals");
-  // xxx  parvalmeth  = PyObject_GetAttrString(geninit_PySEDMODEL,
-  // xxx			       "fetchParVals_BYOSED_4SNANA");
+  handle_python_exception(fnam, "getting fetchParVals attribute of the class");
 
   for(ipar=0; ipar < NPAR; ipar++ ) {
-    pargs  = Py_BuildValue("(s)",parNameList[ipar]);
-    pParVal  = PyEval_CallObject(parvalmeth, pargs);
+    pParVal  = PyObject_CallFunction(parvalmeth, "(s)", parNameList[ipar]);
+    handle_python_exception(fnam, "fetching a parameter value");
     val = PyFloat_AsDouble(pParVal);
     parVal[ipar] = val;
     // printf("   PARVAL    = '%d' \n",  val);

--- a/src/genmag_PySEDMODEL.c
+++ b/src/genmag_PySEDMODEL.c
@@ -667,6 +667,11 @@ int fetchParNames_PySEDMODEL(char **parNameList) {
   if (NPAR == -1) {
     handle_python_exception(fnam, "getting parameter sequence length");
   }
+  if (NPAR > MXPAR_PySEDMODEL) {
+    sprintf(c1err,"fetchParNames returned too long sequence of parameters");
+    sprintf(c2err,"%d is fetched, %d is the maximum allowed value", NPAR, MXPAR_PySEDMODEL);
+    errmsg(SEV_FATAL, 0, fnam, c1err, c2err);
+  }
   for(ipar=0; ipar < NPAR; ipar++ ) {
     pnamesitem = PySequence_GetItem(pNames,ipar);
     if (pnamesitem == NULL) {

--- a/src/genmag_PySEDMODEL.h
+++ b/src/genmag_PySEDMODEL.h
@@ -1,4 +1,5 @@
 // Created Sep 2018
+// Sep 30 2022: MXPAR_PySEDMODEL -> 100 (was 20) for BAYESN
 // Nov 20 2020: MXPAR_PySEDMODEL -> 20 (was 10) for SNEMO
 // Nov 11 2021: Add BayeSN
 
@@ -10,7 +11,7 @@
 // global variables
 
 #define MXLAM_PySEDMODEL  10000  // max wave bins to define SED
-#define MXPAR_PySEDMODEL     20  // max number of params to describe SED
+#define MXPAR_PySEDMODEL     100  // max number of params to describe SED
 #define MXHOSTPAR_PySEDMODEL 20  // max number of items in NAMES_HOSTPAR
 
 #define MODEL_NAME_BYOSED   "BYOSED"


### PR DESCRIPTION
- Python exception handling for `fetchParVals()`
- Increase MXPAR_PySEDMODEL from 20 to 100 for BAYESN (requires 48 parameters)
- Add a check that `NPAR <= MXPAR_PySEDMODEL`