### PR TITLE
add USESIM_REDSHIFT as a command line arg

### DIFF
--- a/src/snlc_fit.car
+++ b/src/snlc_fit.car
@@ -7892,6 +7892,9 @@ c -------------
         else if(MATCH_NMLKEY('USESIM_DLMAG', 1,i,ARGLIST)) then
             READ(ARGLIST(1),*) USESIM_DLMAG
 
+        else if(MATCH_NMLKEY('USESIM_REDSHIFT', 1,i,ARGLIST)) then
+            READ(ARGLIST(1),*) USESIM_REDSHIFT
+
         else if(MATCH_NMLKEY('INIVAL_RV', 1,i,ARGLIST)) then
             READ(ARGLIST(1),*) INIVAL_RV
 


### PR DESCRIPTION
tested using 
```/project2/rkessler/SURVEYS/DES/USERS/helenqu/SNANA/bin/snlc_fit.exe FIT_PIP_HELEN_MISMATCH_TO_WFIT_WITH_CC_LOWZ_DESSIM_WRONGHOST_SERSIC.nml                       VERSION_PHOTOMETRY PIP_HELEN_MISMATCH_TO_WFIT_WITH_CC_LOWZ_DESSIM_WRONGHOST_SERSIC-0014 JOBSPLIT 1 1 TEXTFILE_PREFIX PIP_HELEN_MISMATCH_TO_WFIT_WITH_CC_LOWZ_DESSIM_WRONGHOST_SERSIC-0014_FITOPT001_SPLIT001 ROOTFILE_OUT PIP_HELEN_MISMATCH_TO_WFIT_WITH_CC_LOWZ_DESSIM_WRONGHOST_SERSIC-0014_FITOPT001_SPLIT001.ROOT USESIM_REDSHIFT T```

and confirmed that redshifts (zCMB) were different (by ~10^-3 unless it's a wrong host match)