### PR TITLE
Include epsilon for bayesn

### DIFF
--- a/src/genmag_BAYESN.h
+++ b/src/genmag_BAYESN.h
@@ -1,4 +1,6 @@
 #include "gsl/gsl_linalg.h"
+#include "gsl/gsl_rng.h"
+#include "gsl/gsl_randist.h"
 
 // define pre-processor command to use python interface
 // xxx mark delete (RK) #define USE_BAYESNxxx
@@ -29,6 +31,8 @@ int print_matrix(FILE *f, const gsl_matrix *m);
 
 gsl_matrix *invKD_irr(int Nk, double *xk);
 gsl_matrix *spline_coeffs_irr(int N, int Nk, double *x, double *xk, gsl_matrix *invKD);
+gsl_vector *sample_nu(int n_lam_knots, int n_tau_knots);
+gsl_matrix *sample_epsilon(int n_lam_knots, int n_tau_knots, gsl_vector * nu, gsl_matrix * L_Sigma_epsilon);
 
 char BAYESN_MODELPATH[MXPATHLEN];
 int VERBOSE_BAYESN;


### PR DESCRIPTION
Adds epsilon in under the ENABLE_SCATTER_BAYESN flag. Regression test passed apart from one test (see below), but behaviour of epsilon not thoroughly checked yet. Should really only be turned on in simulations, but the current flag behaviour defaults to turning epsilon on. @RickKessler, please check I didn't mess anything up with the random numbers, etc., and adjust the behaviour of the flag to whatever you see fit!
```
TASK097_CREATE_COV_DES3YR               :  mis-match (REF != TEST)
	 ==> REF:  det(cov) = 8.16518e-78
	 ==> TEST: det(cov) =
TASK098_PSNID_BEST_SDSS_noZprior        :  Perfect match (REF = TEST)
TASK099_PSNID_BEST_SDSS+Zprior          :  Perfect match (REF = TEST)

 TEST Summary
   98 tests have perfect match 
    1 tests have mis-match 

 ALL DONE.
```