### PR TITLE
support filter wavelength limits from the YAML file

### DIFF
--- a/src/genmag_BAYESN.c
+++ b/src/genmag_BAYESN.c
@@ -169,6 +169,22 @@ void read_BAYESN_inputs(char *filename)
               bayesn_var_dptr = &N_SIG;
               break;
           }
+
+          // 20230911 - GSN - need to get the wavelengths from the file
+          if (strcmp(event.data.scalar.value, "L_FILTER_CEN_MIN")==0)
+          {
+              datatype = 1;
+              bayesn_var_dptr = &BAYESN_MODEL_INFO.l_filter_cen_min;
+              break;
+          }
+          if (strcmp(event.data.scalar.value, "L_FILTER_CEN_MAX")==0)
+          {
+              datatype = 1;
+              bayesn_var_dptr = &BAYESN_MODEL_INFO.l_filter_cen_max;
+              break;
+          }
+
+
     
           // next we'll define how to handle the scalars
           if (strcmp(event.data.scalar.value, "M0")==0)
@@ -439,8 +455,12 @@ int init_genmag_BAYESN(char *MODEL_VERSION, int optmask){
 
     SEDMODEL.LAMMIN_ALL = BAYESN_MODEL_INFO.lam_knots[0] ;  // rest-frame SED range
     SEDMODEL.LAMMAX_ALL = BAYESN_MODEL_INFO.lam_knots[BAYESN_MODEL_INFO.n_lam_knots-1] ;
-    SEDMODEL.RESTLAMMIN_FILTERCEN =  SEDMODEL.LAMMIN_ALL + 1200.0 ; // rest-frame central wavelength range
-    SEDMODEL.RESTLAMMAX_FILTERCEN =  SEDMODEL.LAMMAX_ALL - 1200.0 ;
+    
+    // 20230911 - GSN - update filter centers to be defined by the YAML files, rather than use this heuristic
+    // SEDMODEL.RESTLAMMIN_FILTERCEN =  SEDMODEL.LAMMIN_ALL + 1200.0 ; // rest-frame central wavelength range
+    // SEDMODEL.RESTLAMMAX_FILTERCEN =  SEDMODEL.LAMMAX_ALL - 1200.0 ;
+    SEDMODEL.RESTLAMMIN_FILTERCEN =  BAYESN_MODEL_INFO.l_filter_cen_min ; // rest-frame central wavelength range
+    SEDMODEL.RESTLAMMAX_FILTERCEN =  BAYESN_MODEL_INFO.l_filter_cen_max ;
 
     if (VERBOSE_BAYESN > 0)
     {

--- a/src/genmag_BAYESN.h
+++ b/src/genmag_BAYESN.h
@@ -45,7 +45,13 @@ struct {
    int    n_tau_knots;
    int    n_sig_knots;
 
-   // variables read from BayeSN model director
+   // variables read from BayeSN model directory
+   // variables that control the range of validity of the SED
+   double l_filter_cen_min;
+   double l_filter_cen_max;
+   
+   
+   // variables that define the SED 
    // scalars
    double M0;
    double sigma0;


### PR DESCRIPTION
Mini update to support setting the rest-frame wavelength limits of the model from the YAML file (this was the intention, but earlier the limits were hard-coded to SED_MIN/MAX +/- 1200 A). This should prevent early g-band dropout.