### PR TITLE
Corrected DCR RA shift by dividing by cos_DEC

### DIFF
--- a/src/genmag_PySEDMODEL.h
+++ b/src/genmag_PySEDMODEL.h
@@ -4,7 +4,7 @@
 // Nov 11 2021: Add BayeSN
 
 // define pre-processor command to use python interface
-#define USE_PYTHONxxx        
+#define USE_PYTHON         
 
 
 // ===========================================

--- a/src/sntools_output.h
+++ b/src/sntools_output.h
@@ -34,7 +34,7 @@
 
 
 // define flags for software packages
-#define USE_HBOOK     
+#define USE_HBOOKxxx     
 #define USE_ROOT        
 #define USE_TEXT  // always leave this on; same logic as for HBOOK,ROOT, ...
 #define USE_MARZ  // always leave this on

--- a/src/sntools_sim_atmosphere.c
+++ b/src/sntools_sim_atmosphere.c
@@ -667,9 +667,9 @@ void gen_dcr_coordShift(int ep) {
   else
     { cos_q   = 0.0 ; }
 
-  // take projection for RA and DEC shifts in degrees
+  // take projection for RA and DEC shifts in degrees, update 10/3/2023 J.L. dividing RA shift by cos_DEC
   GENLC.dcr_shift[ep]     = DCR_deg ;
-  GENLC.RA_dcr_shift[ep]  = DCR_deg * sin_q ;
+  GENLC.RA_dcr_shift[ep]  = DCR_deg * sin_q / cos_DEC ;
   GENLC.DEC_dcr_shift[ep] = DCR_deg * cos_q ;
 
   // set number of processed spectra (SEDs) to zero so that spectra/SED


### PR DESCRIPTION
As discussed earlier, fixing DCR RA shift calculated from altitude shift by dividing by the cosine of declination. 

Also, noting that the regression test didn't run on my command line probably because of the queue (it's been 4 hours). 