### PR TITLE
Add some stuff to change where bayesn epsilon gets updated

### DIFF
--- a/src/genmag_BAYESN.h
+++ b/src/genmag_BAYESN.h
@@ -34,6 +34,8 @@ gsl_matrix *spline_coeffs_irr(int N, int Nk, double *x, double *xk, gsl_matrix *
 gsl_vector *sample_nu(int n_lam_knots, int n_tau_knots);
 gsl_matrix *sample_epsilon(int n_lam_knots, int n_tau_knots, gsl_vector * nu, gsl_matrix * L_Sigma_epsilon);
 
+void genEPSILON_BAYESN(); // added by ST Mar 22 2024 (HACK HACK)
+
 char BAYESN_MODELPATH[MXPATHLEN];
 int VERBOSE_BAYESN;
 #define OPTMASK_BAYESN_VERBOSE 128
@@ -67,9 +69,8 @@ struct {
    gsl_matrix *W0;
    gsl_matrix *W1;
 
-   //double **L_Sigma_epsilon;
-   //double **W0; 
-   //double **W1; 
+   // running epsilon variable (yikes)
+   gsl_matrix *EPSILON;
 
    // for the base SED - typically Hsiao
    SEDMODEL_FLUX_DEF S0; 

--- a/src/snlc_sim.c
+++ b/src/snlc_sim.c
@@ -11771,6 +11771,7 @@ void gen_event_driver(int ilc) {
       - RISETIME_SHIFT
       - MWEBV
       - GENMAG_OFF_GLOBAL
+      - EPSILON (BAYESN)
 
   These quantities are either read from data files
   to mimic real data, or they are generated randomly.
@@ -11802,6 +11803,8 @@ void gen_event_driver(int ilc) {
      selected in pick_NON1ASED().
   
   Jul 2019: add strong lens option
+
+  Mar 22 2024: add epsilon for BAYESN
 
   *********************************************************/
 
@@ -11899,6 +11902,15 @@ void gen_event_driver(int ilc) {
     // - - - - - - - 
     // get host galaxy extinction for rest-frame models and for NON1A
     gen_modelPar_dust(GENFRAME_OPT);
+
+    // Mar 22 2024
+    // update BAYESN residual scatter
+    // this calls a function from genmag_BAYESN.c
+    // there is a running epsilon variable inside the BAYESN_MODEL_INFO
+    // struct that will be modified by this call
+    if ( INDEX_GENMODEL == MODEL_BAYESN ) {
+        genEPSILON_BAYESN();
+    }
 
     // check for SN params in HOSTLIB
     override_modelPar_from_SNHOST(); 


### PR DESCRIPTION
This one is a bit questionable, so @RickKessler and @gnarayan should definitely check it. Previously, we generated a random draw of BayeSN's residual scatter parameter ($\epsilon$) inside the `genmag_BAYESN` function. This was not correct, as it meant $\epsilon$ got resampled for each passband (when it should just be sampled once per supernova). The consequence was that the residual intrinsic variation added to each band was uncorrelated with the other bands, making it very hard to fit the simulations.

I have made some changes to try to fix this:
 - `EPSILON` is now a part of the `BAYESN_MODEL_INFO` struct (along with the global parameters like `W0`, `W1`, etc.). It is initialised to a matrix of zeros (so if it is not updated, no scatter gets added).
 -  I added a function `genEPSILON_BAYESN()` to `genmag_BAYESN.c`. When called, this function queries the value of `ENABLE_SCATTER_BAYESN`. If true, the `EPSILON` gets updated. Otherwise nothing happens.
 - The `genEPSILON_BAYESN()` function gets invoked in `snlc_sim.c` inside the `gen_event_driver()` function, meaning epsilon will be updated when a new supernova is initialised (I think).

Me and @mattgrayling tested this, and it seemed to produce the desired behaviour, and improved the convergence of Matt's BayeSN fits. Three regression tests failed:
```
TASK047_RESIM_WITH_SPECTRA              :  mis-match (REF != TEST)
	 ==> REF:  SYNMAG = 19.0031 19.3639 19.3726 #
	 ==> TEST: ABORT
TASK101_SCONE_DES_CREATE_HEATMAPS       :  mis-match (REF != TEST)
	 ==> REF:  BLANK (grep failed, no abort)
	 ==> TEST: scone_create_heatmaps = Processed 74
TASK102_SCONE_DES_TRAIN                 :  mis-match (REF != TEST)
	 ==> REF:  BLANK (grep failed, no abort)
	 ==> TEST: scone_train = value: 1.0

 TEST Summary
   99 tests have perfect match 
    3 tests have mis-match 
```