### PR TITLE
Fitzpatrick '99 Update

### DIFF
--- a/src/MWgaldust.c
+++ b/src/MWgaldust.c
@@ -306,14 +306,14 @@ double GALextinct(double RV, double AV, double WAVE, int OPT) {
               D.Scolnic with polynomial fit to ratio of F'99/O'94 vs. lambda.
               O'94 is the opt=94 option and F'99 was computed from 
               http://idlastro.gsfc.nasa.gov/ftp/pro/astro/fm_unred.pro
-              Deprecated to OPT=-99 from OPT=99 September XX 2024.
+              Deprecated to OPT=-99 from OPT=99 September 25 2024.
               Only reliable for RV=3.1.
 
     OPT=99 => use Fitzpatrick 99 (PASP 111, 63) as implemented by S. Thorp.
                 This version directly evaluates the cubic spline in inverse
                 wavelength, as defined by the fm_unred.pro code. Consistent
                 with extinction.py by K. Barbary, and BAYESN F99 implementation.
-                Promoted to OPT=99 September XX 2024.
+                Promoted to OPT=99 September 25 2024.
 
   Returns magnitudes of extinction.
 
@@ -343,7 +343,7 @@ double GALextinct(double RV, double AV, double WAVE, int OPT) {
   Sep 19 2024 ST
    + add an exact Fitzpatrick 99 implementation with opt=9999.
 
-  Sep XX 2024 ST
+  Sep 25 2024 ST
    + Exact F'99 spline implementation promoted to opt=99
    - Old F'99 based on F'99/O'94 ratio deprecated to opt=-99
 
@@ -490,7 +490,7 @@ double GALextinct_Fitz99_exact(double RV, double AV, double WAVE) {
 /*** 
   Created by S. Thorp, Sep 19 2024
 
-  Default Fitzpatrick (1999) implementation since Sep XX 2024
+  Default Fitzpatrick (1999) implementation since Sep 25 2024
 
   Input : 
     AV   = V band (defined to be at 5495 Angstroms) extinction

--- a/src/MWgaldust.c
+++ b/src/MWgaldust.c
@@ -302,15 +302,18 @@ double GALextinct(double RV, double AV, double WAVE, int OPT) {
 
     OPT=94 => use update from O'Donell
 
-    OPT=99 => use Fitzpatrick 99 (PASP 111, 63) as implemented by 
+    OPT=-99 => use Fitzpatrick 99 (PASP 111, 63) as implemented by 
               D.Scolnic with polynomial fit to ratio of F'99/O'94 vs. lambda.
               O'94 is the opt=94 option and F'99 was computed from 
               http://idlastro.gsfc.nasa.gov/ftp/pro/astro/fm_unred.pro
+              Deprecated to OPT=-99 from OPT=99 September XX 2024.
+              Only reliable for RV=3.1.
 
-    OPT=9999 => use Fitzpatrick 99 (PASP 111, 63) as implemented by S. Thorp.
+    OPT=99 => use Fitzpatrick 99 (PASP 111, 63) as implemented by S. Thorp.
                 This version directly evaluates the cubic spline in inverse
                 wavelength, as defined by the fm_unred.pro code. Consistent
                 with extinction.py by K. Barbary, and BAYESN F99 implementation.
+                Promoted to OPT=99 September XX 2024.
 
   Returns magnitudes of extinction.
 
@@ -339,6 +342,10 @@ double GALextinct(double RV, double AV, double WAVE, int OPT) {
 
   Sep 19 2024 ST
    + add an exact Fitzpatrick 99 implementation with opt=9999.
+
+  Sep XX 2024 ST
+   + Exact F'99 spline implementation promoted to opt=99
+   - Old F'99 based on F'99/O'94 ratio deprecated to opt=-99
 
  ***/
 
@@ -483,6 +490,8 @@ double GALextinct_Fitz99_exact(double RV, double AV, double WAVE) {
 /*** 
   Created by S. Thorp, Sep 19 2024
 
+  Default Fitzpatrick (1999) implementation since Sep XX 2024
+
   Input : 
     AV   = V band (defined to be at 5495 Angstroms) extinction
     RV   = assumed A(V)/E(B-V) (e.g., = 3.1 in the LMC)
@@ -491,7 +500,7 @@ Returns :
     XT = magnitudes of extinction
 ***/
 
-    char fnam[] = "F99exact" ;
+    char fnam[] = "GALextinct_Fitz99_exact" ;
 
     // constants
     double x02, gamma2, c1, c2, c3, c4, c5;

--- a/src/MWgaldust.h
+++ b/src/MWgaldust.h
@@ -6,7 +6,7 @@
 //    OPT_MWCOLORLAW_FITZ99_APPROX = 99. After more testing, the plan is
 //    make OPT_MWCOLORLAW_FITZ99_EXACT=99 the new default and allow
 //    OPT_MWCOLORLAW_FITZ99_APPROX = -99 to revert back to old approximation.
-// Sep XX 2024: S. Thorp, R. Kessler
+// Sep 25 2024: S. Thorp, R. Kessler
 //    define OPT_MWCOLORLAW_FITZ99_EXACT = 99
 //    define OPT_MWCOLORLAW_FITZ99_APPROX = -99
 // =======================================

--- a/src/MWgaldust.h
+++ b/src/MWgaldust.h
@@ -6,15 +6,17 @@
 //    OPT_MWCOLORLAW_FITZ99_APPROX = 99. After more testing, the plan is
 //    make OPT_MWCOLORLAW_FITZ99_EXACT=99 the new default and allow
 //    OPT_MWCOLORLAW_FITZ99_APPROX = -99 to revert back to old approximation.
-//            
+// Sep XX 2024: S. Thorp, R. Kessler
+//    define OPT_MWCOLORLAW_FITZ99_EXACT = 99
+//    define OPT_MWCOLORLAW_FITZ99_APPROX = -99
 // =======================================
 
 
 #define OPT_MWCOLORLAW_OFF      0  // No Extinction applied.
 #define OPT_MWCOLORLAW_CCM89   89  // Clayton,Cardelli,Matheson, 1989
 #define OPT_MWCOLORLAW_ODON94  94  // O'Donnel 1994 update
-#define OPT_MWCOLORLAW_FITZ99_APPROX  99   // approx Fitzpatrick 1999 (D.Scolnic, 2013)
-#define OPT_MWCOLORLAW_FITZ99_EXACT   9999 // exact Fitzpatrick 1999 (S.Thorp, 2024)
+#define OPT_MWCOLORLAW_FITZ99_APPROX  -99   // approx Fitzpatrick 1999 (D.Scolnic, 2013)
+#define OPT_MWCOLORLAW_FITZ99_EXACT   99 // exact Fitzpatrick 1999 (S.Thorp, 2024)
 
 #define OPT_MWEBV_OFF            0  // no extinction
 #define OPT_MWEBV_FILE           1  // FILE value (simlib or data header)


### PR DESCRIPTION
**Planned Merge: 25 September 2024**

Fixes #1422 

This PR will change the default implementation of the Fitzpatrick (1999) dust extinction law. 

Once this PR is merged, setting `OPT_MWCOLORLAW = 99` will invoke a new C implementation of the dust law. This is based on a cubic spline, and follows the reference implementations of the extinction law in [`extinction.py`](https://github.com/kbarbary/extinction) and [`FM_UNRED.pro`](http://astro.uni-tuebingen.de/software/idl/astrolib/astro/fm_unred.pro). We have tested the new C function from 1000-25000Å and found that it agrees well with `extinction.py` for a range of $R_V$ values.

The previous Fitzpatrick (1999) implementation will be maintained for backwards compatibility, but will need to be invoked by setting `OPT_MWCOLORLAW = -99`. This old version of the dust law was based on a polynomial in $\lambda$ that was fit to the ratio of the Fitzpatrick (1999) and O'Donnell (1994) extinction laws. This provides a reasonable approximation for $R_V=3.1$, but breaks down for $R_V\neq3.1$. The new version should be valid for any $R_V$.