### PR TITLE
BayeSN extrapolation and tidying

### DIFF
--- a/src/genmag_BAYESN.c
+++ b/src/genmag_BAYESN.c
@@ -43,15 +43,36 @@ Each sample counts as 0.01 seconds.
 // #include "sntools_genSmear.h" // Aug 30 2019
 
 // ============ MANGLED FORTRAN FUNCTIONS =============
-int init_genmag_bayesn__( char *model_version, char *model_extrap, int *optmask) {
+int init_genmag_bayesn__(
+         char * model_version
+        ,char * model_extrap
+        ,int  * optmask
+) {
     int istat;
-    istat = init_genmag_BAYESN ( model_version, model_extrap, *optmask) ;
+    istat = init_genmag_BAYESN(model_version, model_extrap, *optmask) ;
     return istat;
 }
 
+void genmag_bayesn__(
+         int    * OPTMASK
+        ,int    * ifilt_obs
+        ,double * parlist_SN
+        ,double * mwebv
+        ,double * z
+        ,int    * Nobs
+        ,double * Tobs_list
+        ,double * magobs_list
+        ,double * magerr_list
+) {
+    genmag_BAYESN(*OPTMASK, *ifilt_obs, parlist_SN, *mwebv, *z
+                  ,*Nobs, Tobs_list, magobs_list, magerr_list);
+    return;
+}
 
-void read_BAYESN_inputs(char *filename)
-{
+// =====================================================
+// ============ MAIN BAYESN C FUNCTIONS =============
+void read_BAYESN_inputs(char * filename) {
+    
     char fnam[] = "read_BAYESN_inputs";
 
     // -------------- BEGIN -------------
@@ -331,12 +352,12 @@ void read_BAYESN_inputs(char *filename)
     BAYESN_MODEL_INFO.n_lam_knots = (int) N_LAM;
     BAYESN_MODEL_INFO.n_tau_knots = (int) N_TAU;
     BAYESN_MODEL_INFO.n_sig_knots = (int) N_SIG;
-    BAYESN_MODEL_INFO.W0 = gsl_matrix_alloc(BAYESN_MODEL_INFO.n_lam_knots, 
-                                            BAYESN_MODEL_INFO.n_tau_knots);
-    BAYESN_MODEL_INFO.W1 = gsl_matrix_alloc(BAYESN_MODEL_INFO.n_lam_knots, 
-                                            BAYESN_MODEL_INFO.n_tau_knots);
-    BAYESN_MODEL_INFO.L_Sigma_epsilon = gsl_matrix_alloc(BAYESN_MODEL_INFO.n_sig_knots, 
-                                                         BAYESN_MODEL_INFO.n_sig_knots);
+    BAYESN_MODEL_INFO.W0 = gsl_matrix_alloc(BAYESN_MODEL_INFO.n_lam_knots 
+                                            ,BAYESN_MODEL_INFO.n_tau_knots);
+    BAYESN_MODEL_INFO.W1 = gsl_matrix_alloc(BAYESN_MODEL_INFO.n_lam_knots 
+                                            ,BAYESN_MODEL_INFO.n_tau_knots);
+    BAYESN_MODEL_INFO.L_Sigma_epsilon = gsl_matrix_alloc(BAYESN_MODEL_INFO.n_sig_knots 
+                                                         ,BAYESN_MODEL_INFO.n_sig_knots);
 
     // finally initalize the GSL matrices 
     int k = 0, j;
@@ -362,22 +383,26 @@ void read_BAYESN_inputs(char *filename)
 
 } // end read_BAYESN_inputs
 
-int init_genmag_BAYESN(char *MODEL_VERSION, char *MODEL_EXTRAP, int optmask){
-  // Created by. S.Thorp and G.Narayan
-  // Read & initialize BAYESN model.
-  //
-  //  HISTORY
-  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // Sep 18 2023: 
-  //     RK - add MODEL_EXTRAP argument. 
-  // Apr 23 2025:
-  //     ST - update extrapolation behaviour
-  //        - now uses BayeSN's default linear extrap rule for -20<Trest<85
-  //        - uses flux=0 for Trest<-20 and SNANA linear extrap for Trest>85
-
-  // Old To Dos (from RK?):
-  // -  Implement MODEL_EXTRAP following logic in genmag_SALT2.c
-  // -  make sure that default modelflux_extrap(...) is called correctly.
+int init_genmag_BAYESN(
+         char * MODEL_VERSION // (I) BayeSN model version
+        ,char * MODEL_EXTRAP  // (I) Extrap behaviour (NOT IMPLEMENTED)
+        ,int    optmask       // (I) Option mask
+) {
+    // Created by. S.Thorp and G.Narayan
+    // Read & initialize BAYESN model.
+    //
+    //  HISTORY
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Sep 18 2023: 
+    //     RK - add MODEL_EXTRAP argument. 
+    // Apr 23 2025:
+    //     ST - update extrapolation behaviour
+    //        - now uses BayeSN's default linear extrap rule for -20<Trest<85
+    //        - uses flux=0 for Trest<-20 and SNANA linear extrap for Trest>85
+  
+    // Old To Dos (from RK?):
+    // -  Implement MODEL_EXTRAP following logic in genmag_SALT2.c
+    // -  make sure that default modelflux_extrap(...) is called correctly.
 
     int  ised;
     int  retval = 0   ;
@@ -404,8 +429,8 @@ int init_genmag_BAYESN(char *MODEL_VERSION, char *MODEL_EXTRAP, int optmask){
     if (optmask & OPTMASK_BAYESN_SCATTER_DEFAULT) {
         // sanity check and abort on confusing input
         if ( optmask & OPTMASK_BAYESN_SCATTER_ALL ) {
-            sprintf(c1err, "Ambiguous scatter configuration requested! Found %d in OPTMASK!", 
-                    optmask & (OPTMASK_BAYESN_SCATTER_DEFAULT + OPTMASK_BAYESN_SCATTER_ALL) );
+            sprintf(c1err, "Ambiguous scatter configuration requested! Found %d in OPTMASK!"
+                    ,optmask & (OPTMASK_BAYESN_SCATTER_DEFAULT + OPTMASK_BAYESN_SCATTER_ALL) );
             sprintf(c2err, "If bit 1 is set (enable default scatter), no other scatter bits can be set!");
             errmsg(SEV_FATAL, 0, fnam, c1err, c2err); 
         }
@@ -419,11 +444,10 @@ int init_genmag_BAYESN(char *MODEL_VERSION, char *MODEL_EXTRAP, int optmask){
         ENABLE_SCATTER_BAYESN = optmask & OPTMASK_BAYESN_SCATTER_ALL;
     }
     // print the scatter flag we ended up with
-    printf("ENABLE_SCATTER_BAYESN flag is %d (DELTAM %scluded; EPSILON %scluded)\n", 
-            ENABLE_SCATTER_BAYESN, 
-            (ENABLE_SCATTER_BAYESN & 4) ? "in" : "ex",
-            (ENABLE_SCATTER_BAYESN & 2) ? "in" : "ex"
-          );
+    printf("ENABLE_SCATTER_BAYESN flag is %d (DELTAM %scluded; EPSILON %scluded)\n" 
+           ,ENABLE_SCATTER_BAYESN
+           ,(ENABLE_SCATTER_BAYESN & 4) ? "in" : "ex"
+           ,(ENABLE_SCATTER_BAYESN & 2) ? "in" : "ex");
     
     // this loads all the BAYESN model components into the BAYESN_MODEL_INFO struct
     char version[60];
@@ -446,8 +470,8 @@ int init_genmag_BAYESN(char *MODEL_VERSION, char *MODEL_EXTRAP, int optmask){
     double Tlower    = -20.0 ; // formerly BAYESN_MODEL_INFO.tau_knots[0]
     double Tupper    =  85.0 ; // formerly BAYESN_MODEL_INFO.tau_knots[BAYESN_MODEL_INFO.n_tau_knots-1] ;
     double Trange[2] = {Tlower, Tupper};
-    double Lrange[2] = {BAYESN_MODEL_INFO.lam_knots[0], 
-                        BAYESN_MODEL_INFO.lam_knots[BAYESN_MODEL_INFO.n_lam_knots-1]};
+    double Lrange[2] = {BAYESN_MODEL_INFO.lam_knots[0]
+                        ,BAYESN_MODEL_INFO.lam_knots[BAYESN_MODEL_INFO.n_lam_knots-1]};
     
     istat = rd_sedFlux(SED_filepath, "Hsiao Template", Trange, Lrange
                        ,MXBIN_DAYSED_SEDMODEL, MXBIN_LAMSED_SEDMODEL, 0
@@ -464,33 +488,37 @@ int init_genmag_BAYESN(char *MODEL_VERSION, char *MODEL_EXTRAP, int optmask){
 
     filtdump_SEDMODEL();
 
-    SEDMODEL.LAMMIN_ALL = BAYESN_MODEL_INFO.lam_knots[0] ;  // rest-frame SED range
-    SEDMODEL.LAMMAX_ALL = BAYESN_MODEL_INFO.lam_knots[BAYESN_MODEL_INFO.n_lam_knots-1] ;
-    SEDMODEL.RESTLAMMIN_FILTERCEN =  BAYESN_MODEL_INFO.l_filter_cen_min ; // rest-frame central wavelength range
+    // rest-frame wavelength range of SED
+    SEDMODEL.LAMMIN_ALL           = BAYESN_MODEL_INFO.lam_knots[0] ;
+    SEDMODEL.LAMMAX_ALL           = BAYESN_MODEL_INFO.lam_knots[BAYESN_MODEL_INFO.n_lam_knots-1] ;
+    // rest-frame central wavelength range allowed for filters
+    SEDMODEL.RESTLAMMIN_FILTERCEN =  BAYESN_MODEL_INFO.l_filter_cen_min ; 
     SEDMODEL.RESTLAMMAX_FILTERCEN =  BAYESN_MODEL_INFO.l_filter_cen_max ;
 
     if ( VERBOSE_BAYESN > 0 ) {
-        printf("DEBUG: LIMITS OF FILTER CENTRAL WAVELENGTH: %.1f, %.1f\n",
-                SEDMODEL.RESTLAMMIN_FILTERCEN, SEDMODEL.RESTLAMMAX_FILTERCEN);
-        printf("DEBUG: LIMITS OF SED WAVELENGTH: %.1f, %.1f\n",
-                SEDMODEL.LAMMIN_ALL, SEDMODEL.LAMMAX_ALL);
+        printf("DEBUG: LIMITS OF FILTER CENTRAL WAVELENGTH: %.1f, %.1f\n"
+               ,SEDMODEL.RESTLAMMIN_FILTERCEN, SEDMODEL.RESTLAMMAX_FILTERCEN);
+        printf("DEBUG: LIMITS OF SED WAVELENGTH: %.1f, %.1f\n"
+               ,SEDMODEL.LAMMIN_ALL, SEDMODEL.LAMMAX_ALL);
     }
 
     //compute the inverse KD matrices and J_lam 
-    BAYESN_MODEL_INFO.KD_tau = invKD_irr(BAYESN_MODEL_INFO.n_tau_knots,
-            BAYESN_MODEL_INFO.tau_knots);
-    BAYESN_MODEL_INFO.KD_lam = invKD_irr(BAYESN_MODEL_INFO.n_lam_knots,
-            BAYESN_MODEL_INFO.lam_knots);
-    BAYESN_MODEL_INFO.J_lam = spline_coeffs_irr(BAYESN_MODEL_INFO.S0.NLAM,
-            BAYESN_MODEL_INFO.n_lam_knots, BAYESN_MODEL_INFO.S0.LAM,
-            BAYESN_MODEL_INFO.lam_knots, BAYESN_MODEL_INFO.KD_lam);
+    BAYESN_MODEL_INFO.KD_tau = invKD_irr(BAYESN_MODEL_INFO.n_tau_knots
+                                         ,BAYESN_MODEL_INFO.tau_knots);
+    BAYESN_MODEL_INFO.KD_lam = invKD_irr(BAYESN_MODEL_INFO.n_lam_knots
+                                         ,BAYESN_MODEL_INFO.lam_knots);
+    BAYESN_MODEL_INFO.J_lam = spline_coeffs_irr(BAYESN_MODEL_INFO.S0.NLAM
+                                                ,BAYESN_MODEL_INFO.n_lam_knots
+                                                ,BAYESN_MODEL_INFO.S0.LAM
+                                                ,BAYESN_MODEL_INFO.lam_knots
+                                                ,BAYESN_MODEL_INFO.KD_lam);
 
     // allocate memory for epsilon (which will keep being overwritten)
     // the genEPSILON_BAYESN() function will update this when it gets
     // invoked in snlc_sim
     // added by ST on Mar 22 2024 (sorry)
-    BAYESN_MODEL_INFO.EPSILON = gsl_matrix_alloc(BAYESN_MODEL_INFO.n_lam_knots,
-                                                 BAYESN_MODEL_INFO.n_tau_knots);
+    BAYESN_MODEL_INFO.EPSILON = gsl_matrix_alloc(BAYESN_MODEL_INFO.n_lam_knots
+                                                 ,BAYESN_MODEL_INFO.n_tau_knots);
     gsl_matrix_set_zero(BAYESN_MODEL_INFO.EPSILON);
 
     // init _LAST variables for extinction storage
@@ -505,45 +533,44 @@ int init_genmag_BAYESN(char *MODEL_VERSION, char *MODEL_EXTRAP, int optmask){
 
 } // end init_genmag_BAYESN
 
-// =====================================================
 void genmag_BAYESN(
-         int     OPTMASK      // (I) bit-mask of options (LSB=0)
-        ,int     ifilt_obs    // (I) absolute filter index
-        ,double *parList_SN   // (I) DLMAG, THETA, AV, RV
-        ,double  mwebv        // (I) Galactic extinction: E(B-V)
-        ,double  z            // (I) Supernova redshift
-        ,int     Nobs         // (I) number of epochs
-        ,double *Tobs_list    // (I) list of Tobs (w.r.t peakMJD) 
-        ,double *magobs_list  // (O) observed mag values
-        ,double *magerr_list  // (O) model mag errors
-    ) {
+         int      OPTMASK      // (I) bit-mask of options (LSB=0)
+        ,int      ifilt_obs    // (I) absolute filter index
+        ,double * parList_SN   // (I) DLMAG, THETA, AV, RV
+        ,double   mwebv        // (I) Galactic extinction: E(B-V)
+        ,double   z            // (I) Supernova redshift
+        ,int      Nobs         // (I) number of epochs
+        ,double * Tobs_list    // (I) list of Tobs (w.r.t peakMJD) 
+        ,double * magobs_list  // (O) observed mag values
+        ,double * magerr_list  // (O) model mag errors
+) {
 
     double DLMAG = parList_SN[0] ;
     double THETA = parList_SN[1] ;
     double AV    = parList_SN[2] ;
     double RV    = parList_SN[3] ;
 
-    int     OPT_COLORLAW     = MWXT_SEDMODEL.OPT_COLORLAW;
-    double *PARLIST_COLORLAW = MWXT_SEDMODEL.PARLIST_COLORLAW;
-    double  z1, meanlam_obs, meanlam_rest, ZP, PARDUM=0.0 ; 
-    double  t0, t1, f0, f1, flux ;
+    int      OPT_COLORLAW     = MWXT_SEDMODEL.OPT_COLORLAW;
+    double * PARLIST_COLORLAW = MWXT_SEDMODEL.PARLIST_COLORLAW;
+    double   z1, meanlam_obs, meanlam_rest, ZP, PARDUM=0.0 ; 
+    double   t0, t1, f0, f1, flux ;
 
-    int     MEMD        = sizeof(double)*Nobs;
-    double *flux_list   = malloc(MEMD); // RK
-    double *Trest_list  = malloc(MEMD); 
-    int    *extrap_flag = malloc(MEMD);  
-    int    *preexp_flag = malloc(MEMD); // ST
+    int      MEMD        = sizeof(double)*Nobs;
+    double * flux_list   = malloc(MEMD); // RK
+    double * Trest_list  = malloc(MEMD); 
+    int    * extrap_flag = malloc(MEMD);  
+    int    * preexp_flag = malloc(MEMD); // ST
 
-    char   *cfilt ;
-    int     ifilt = 0, i, o ; 
+    char   * cfilt ;
+    int      ifilt = 0, i, o ; 
     
     // allocate matrices for the spline operations
-    gsl_vector_view  j_lam;
-    gsl_matrix      *J_tau;
-    gsl_matrix      *W       = gsl_matrix_alloc(BAYESN_MODEL_INFO.n_lam_knots,
-                                                BAYESN_MODEL_INFO.n_tau_knots);
-    gsl_matrix      *WJ      = gsl_matrix_alloc(BAYESN_MODEL_INFO.n_lam_knots, Nobs);
-    gsl_vector      *jWJ     = gsl_vector_alloc(Nobs);
+    gsl_vector_view j_lam;
+    gsl_matrix    * J_tau;
+    gsl_matrix    * W   = gsl_matrix_alloc(BAYESN_MODEL_INFO.n_lam_knots
+                                           ,BAYESN_MODEL_INFO.n_tau_knots);
+    gsl_matrix    * WJ  = gsl_matrix_alloc(BAYESN_MODEL_INFO.n_lam_knots, Nobs);
+    gsl_vector    * jWJ = gsl_vector_alloc(Nobs);
 
     int     nlam_filt, ilam_filt;
     int     nday_model, nlam_model, ilam_model_blue, ilam_model_red ;
@@ -600,21 +627,21 @@ void genmag_BAYESN(
     daystep_model    = BAYESN_MODEL_INFO.S0.DAYSTEP; // RK
 
     // compute ilam_model_blue[red] instead of brute-force search (RK)
-    dlam_tmp = lam_filt_array[0] - z1*lam_model_array[0];
-    ilam_model_blue = (int)( dlam_tmp / (z1*lamstep_model) ) + 1 ; // RK
-    dlam_tmp = lam_filt_array[nlam_filt-1] - z1*lam_model_array[0];
-    ilam_model_red  = (int)( dlam_tmp / (z1*lamstep_model) ) ; // RK
+    dlam_tmp         = lam_filt_array[0] - z1*lam_model_array[0];
+    ilam_model_blue  = (int)( dlam_tmp / (z1*lamstep_model) ) + 1 ; // RK
+    dlam_tmp         = lam_filt_array[nlam_filt-1] - z1*lam_model_array[0];
+    ilam_model_red   = (int)( dlam_tmp / (z1*lamstep_model) ) ; // RK
 
     // compute the matrix for time interpolation
-    J_tau = spline_coeffs_irr(Nobs, BAYESN_MODEL_INFO.n_tau_knots,
-              Trest_list, BAYESN_MODEL_INFO.tau_knots, BAYESN_MODEL_INFO.KD_tau);
+    J_tau = spline_coeffs_irr(Nobs, BAYESN_MODEL_INFO.n_tau_knots, Trest_list
+                              ,BAYESN_MODEL_INFO.tau_knots, BAYESN_MODEL_INFO.KD_tau);
 
     // compute W0 + THETA*W1 + EPSILON
     int wx, wy;
     int nx = BAYESN_MODEL_INFO.n_lam_knots;
     int ny = BAYESN_MODEL_INFO.n_tau_knots;
-    for (wx=0; wx < nx; wx++)    {
-        for (wy=0; wy < ny; wy++)   {
+    for (wx=0; wx < nx; wx++) {
+        for (wy=0; wy < ny; wy++) {
             double W0_val = gsl_matrix_get(BAYESN_MODEL_INFO.W0, wx, wy) ;
             double W1_val = gsl_matrix_get(BAYESN_MODEL_INFO.W1, wx, wy) ;
             double EP_val = gsl_matrix_get(BAYESN_MODEL_INFO.EPSILON, wx, wy);
@@ -630,26 +657,26 @@ void genmag_BAYESN(
     // interpolate the filter wavelengths on to the model in the observer frame
     // usually this is OK because the filters are more coarsely defined than the model
     // that may not be the case with future surveys and we should revisit
-    int    this_nlam = ilam_model_red - ilam_model_blue + 1;
-    int    OPT_INTERP = 1; // 1=linear, 2=quadratic
+    int    this_nlam  = ilam_model_red - ilam_model_blue + 1;
+    int    OPT_INTERP = 1 ;         // 1=linear, 2=quadratic
     int    q_lam, q_day;
     double this_lam, lam_model ;
     double this_trans, tr0, tr1, frac ;
-    double eA_lam_MW, eA_lam_host; // store MW and host dust law at current wl
-    double eW, S0_lam; // store other SED  bits
+    double eA_lam_MW, eA_lam_host ; // store MW and host dust law at current wl
+    double eW, S0_lam ;             // store other SED  bits
 
     // loop over model wavelengths within the filter
     for (q_lam = ilam_model_blue; q_lam < ilam_model_red; q_lam++) {
 
-        lam_model  = lam_model_array[q_lam]; // rest-frame model lam
-        this_lam   = lam_model_array[q_lam]*z1; // obs-frame
+        lam_model = lam_model_array[q_lam]; // rest-frame model lam
+        this_lam  = lam_model_array[q_lam]*z1; // obs-frame
 
         // RK - get lam-index for filter
         ilam_filt   = (int)((this_lam - lam_filt_array[0])/lamstep_filt);
         if ( ilam_filt < 0 || ilam_filt >= nlam_filt ) {
             sprintf(c1err,"Invalid ilam_filt=%d", ilam_filt);
-            sprintf(c2err,"Nlam_filt=%d for %s lam=%f ", 
-                    nlam_filt, cfilt, this_lam);
+            sprintf(c2err,"Nlam_filt=%d for %s lam=%f "
+                    ,nlam_filt, cfilt, this_lam);
             errmsg(SEV_FATAL, 0, fnam, c1err, c2err); 
         }
 
@@ -658,9 +685,9 @@ void genmag_BAYESN(
         // (for slight speed improvement, create this_trans_map[ifilt][q_lam]
         //  in init_genmag_BAYESN)
         if ( ilam_filt < nlam_filt-1 ) {
-            tr0  = trans_filt_array[ilam_filt];
-            tr1  = trans_filt_array[ilam_filt+1];
-            frac = ( this_lam - lam_filt_array[ilam_filt] ) / lamstep_filt;
+            tr0        = trans_filt_array[ilam_filt];
+            tr1        = trans_filt_array[ilam_filt+1];
+            frac       = ( this_lam - lam_filt_array[ilam_filt] ) / lamstep_filt;
             this_trans = tr0 + frac*(tr1-tr0);
         } else {
             this_trans = trans_filt_array[ilam_filt];
@@ -675,20 +702,20 @@ void genmag_BAYESN(
         if ( USE_TABLE_XTMW  ) {
             eA_lam_MW = SEDMODEL_TABLE_MWXT_FRAC[ifilt][ilam_filt] ; // RK
         } else {
-            double RV_MW = MWXT_SEDMODEL.RV;
-            double AV_MW = RV_MW * mwebv;
-            double XTMAG_MW = GALextinct(RV_MW, AV_MW, this_lam,
-                                         OPT_COLORLAW, PARLIST_COLORLAW, fnam);
-            eA_lam_MW = pow(10.0, -0.4*XTMAG_MW);
+            double RV_MW    = MWXT_SEDMODEL.RV;
+            double AV_MW    = RV_MW * mwebv;
+            double XTMAG_MW = GALextinct(RV_MW, AV_MW, this_lam
+                                         ,OPT_COLORLAW, PARLIST_COLORLAW, fnam);
+            eA_lam_MW       = pow(10.0, -0.4*XTMAG_MW);
         }
 
         // get host extinction
         if ( USE_TABLE_XThost ) {
             eA_lam_host = SEDMODEL_TABLE_HOSTXT_FRAC[ifilt][ilam_filt]; // RK
         } else {
-            double XTMAG_host = GALextinct(RV, AV, lam_model,
-                                           OPT_COLORLAW, PARLIST_COLORLAW, fnam );
-            eA_lam_host = pow(10.0, -0.4*XTMAG_host);
+            double XTMAG_host = GALextinct(RV, AV, lam_model
+                                           ,OPT_COLORLAW, PARLIST_COLORLAW, fnam);
+            eA_lam_host       = pow(10.0, -0.4*XTMAG_host);
         }
       
         // loop over observations and accumulate the contribution of the
@@ -731,11 +758,11 @@ void genmag_BAYESN(
     gsl_vector_free(jWJ);
 
     if (VERBOSE_BAYESN > 0) {
-        printf("DEBUG: BAYESN_MODEL_INFO.M0: %.2f   DLMAG: %.2f   ZP: %.2f   THETA: %.2f   AV: %.2f\n",
-                BAYESN_MODEL_INFO.M0, DLMAG, ZP, THETA, AV);
+        printf("DEBUG: BAYESN_MODEL_INFO.M0: %.2f   DLMAG: %.2f   ZP: %.2f   THETA: %.2f   AV: %.2f\n"
+               ,BAYESN_MODEL_INFO.M0, DLMAG, ZP, THETA, AV);
     }
 
-    //double hc_local   = hc ; // ST - why do we do this? I've commented it out
+    double hc_local = hc ; // ST - why do we do this? not having it breaks everything
     /* XXX mark delete XXX
     double Trest_edge     = BAYESN_MODEL_INFO.S0.DAY[BAYESN_MODEL_INFO.S0.NDAY-1] ; // ST - updated 
     int    EXTRAPFLAG_DMP = 0 ;
@@ -747,10 +774,8 @@ void genmag_BAYESN(
     for (o = 0; o < Nobs; o++) {
         // ST - I am deprecating the below in favour of BayeSN's inbuilt extrap
         //    - For things beyond the Hsiao07 base template, return undefined
+        //    - For things within Hsiao07, use the BayeSN extrap rule
         /* XXX mark delete XXX
-        // RK - check extrap flag to allow slop in fitted PEAKMJD
-        // ST - this will be triggered if Trest exceeds the base template
-        //    - updates flux based on SNANA extrapolation rule
         if ( extrap_flag[o] ) {
             flux_edge    = flux_list[o];
             slope_flux   = -flux_edge * 0.05; // dF/dt hack
@@ -773,7 +798,7 @@ void genmag_BAYESN(
         // otherwise fill out the magobs list
         } else {
             magobs_list[o] = BAYESN_MODEL_INFO.M0 + BAYESN_MODEL_INFO.DELTAM
-                           + DLMAG - 2.5*log10(flux_list[o]/hc) + ZP; 
+                           + DLMAG - 2.5*log10(flux_list[o]/hc_local) + ZP; 
             magerr_list[o] = 0.01; // RK 0.1 is too big for LCfit
         }
     } // end second o loop over Nobs bins
@@ -793,23 +818,13 @@ void genmag_BAYESN(
 
 } //End of genmag_BAYESN
 
+// =====================================================
+// ============ SPLINE FUNCTIONS =============
 
-// =================================
- 
-void genmag_bayesn__(int *OPTMASK, int *ifilt_obs, double *parlist_SN,
-                     double *mwebv, double *z, int *Nobs,
-                     double *Tobs_list, double *magobs_list,
-                     double *magerr_list) {
-    genmag_BAYESN(*OPTMASK, *ifilt_obs, parlist_SN, *mwebv, *z,
-                    *Nobs, Tobs_list, magobs_list, magerr_list);
-    return;
-}
-
-void dump_SED_element(FILE * file, double wave, double value) {
-   fprintf(file, "%.2f %e", wave, value);
-}
-
-gsl_matrix *invKD_irr(int Nk, double *xk) {
+gsl_matrix * invKD_irr(
+         int      Nk // (I) Number of spline knots
+        ,double * xk // (I) Spline knot locations
+) {
     //FIXME I'm pretty sure this whole thing could be done better by using 
     //the GSL tridiagonal solver. This is just a direct port of my python.
     
@@ -856,11 +871,16 @@ gsl_matrix *invKD_irr(int Nk, double *xk) {
     gsl_matrix_free(D);
 
     return M;
-}
+} // end invKD_irr
 
-// =======================================
-gsl_matrix *spline_coeffs_irr(int N, int Nk, double *x, double *xk, 
-                              gsl_matrix *invKD) {
+
+gsl_matrix * spline_coeffs_irr(
+         int          N      // (I) Number of points to evaluate spline at
+        ,int          Nk     // (I) Number of spline knots
+        ,double     * x      // (I) Locations to evaluate at
+        ,double     * xk     // (I) Locations of knots
+        ,gsl_matrix * invKD  // (I) K^{-1}D matrix
+) {
 
     gsl_matrix * J = gsl_matrix_alloc(N, Nk); 
     gsl_matrix_set_zero(J);
@@ -878,8 +898,8 @@ gsl_matrix *spline_coeffs_irr(int N, int Nk, double *x, double *xk,
             gsl_matrix_set(J, i, Nk-1, b);
             //FIXME I can probably do this by accessing a row and modifying
             for (j=0; j<Nk; j++) {
-                gsl_matrix_set(  J, i, j, gsl_matrix_get(J, i, j)
-                                 + f*gsl_matrix_get(invKD, Nk-2, j)  );
+                gsl_matrix_set(J, i, j, gsl_matrix_get(J, i, j)
+                                        + f*gsl_matrix_get(invKD, Nk-2, j));
             }
         } else if (x[i] < xk[0]) {
             h = xk[1] - xk[0];
@@ -890,8 +910,8 @@ gsl_matrix *spline_coeffs_irr(int N, int Nk, double *x, double *xk,
             gsl_matrix_set(J, i, 0, a);
             gsl_matrix_set(J, i, 1, b);
             for (j=0; j<Nk; j++) {
-                gsl_matrix_set(  J, i, j, gsl_matrix_get(J, i, j)
-                                 - f*gsl_matrix_get(invKD, 1, j)  );
+                gsl_matrix_set(J, i, j, gsl_matrix_get(J, i, j)
+                                        - f*gsl_matrix_get(invKD, 1, j));
             }
         } else {
             q = 0;
@@ -909,9 +929,9 @@ gsl_matrix *spline_coeffs_irr(int N, int Nk, double *x, double *xk,
             gsl_matrix_set(J, i, q,   a);
             gsl_matrix_set(J, i, q+1, b);
             for (j=0; j<Nk; j++) {
-                gsl_matrix_set(  J, i, j, gsl_matrix_get(J, i, j)
-                                 + c*gsl_matrix_get(invKD, q,   j)
-                                 + d*gsl_matrix_get(invKD, q+1, j)  );
+                gsl_matrix_set(J, i, j, gsl_matrix_get(J, i, j)
+                                        + c*gsl_matrix_get(invKD, q,   j)
+                                        + d*gsl_matrix_get(invKD, q+1, j));
             }
         }
     }
@@ -920,11 +940,15 @@ gsl_matrix *spline_coeffs_irr(int N, int Nk, double *x, double *xk,
 
 } // end spline_coeffs_irr 
 
-// =================================================
+// =====================================================
+// ============ EPSILON (RESIDUAL SCATTER) FUNCTIONS =============
+
 // This function creates a vector of N(0,1) draws
-gsl_vector *sample_nu(int n_lam_knots, int n_tau_knots) {
-    int i;
-    int n_knots = (n_lam_knots-2)*n_tau_knots;
+gsl_vector * sample_nu(
+         int n_lam_knots // (I) Number of wavelength knots
+        ,int n_tau_knots // (I) Number of phase knots
+) {
+    int i, n_knots  = (n_lam_knots-2)*n_tau_knots;
     gsl_vector * nu = gsl_vector_alloc(n_knots);
     for (i=0; i<n_knots; i++) {
         gsl_vector_set(nu, i, getRan_Gauss(1));
@@ -933,7 +957,12 @@ gsl_vector *sample_nu(int n_lam_knots, int n_tau_knots) {
 } // end sample_nu
 
 // This function translates a vector of N(0,1) draws into epsilon
-gsl_matrix *sample_epsilon(int n_lam_knots, int n_tau_knots, gsl_vector * nu, gsl_matrix * L_Sigma_epsilon) {
+gsl_matrix * sample_epsilon(
+         int          n_lam_knots     // (I) Number of wavelength knots
+        ,int          n_tau_knots     // (I) Number of phase knots
+        ,gsl_vector * nu              // (I) Vector of Gaussian RVs
+        ,gsl_matrix * L_Sigma_epsilon // (I) Cholesky factor of residual cov.
+) {
     gsl_vector * epsilon_vec = gsl_vector_alloc((n_lam_knots-2)*n_tau_knots);
     gsl_matrix * epsilon_mat = gsl_matrix_alloc(n_lam_knots, n_tau_knots);
 
@@ -966,15 +995,18 @@ void genSCATTER_BAYESN() {
     // if ENABLE_SCATTER_BAYESN = 6, EPSILON and DELTAM are included
     // sample EPSILON
     if (ENABLE_SCATTER_BAYESN & OPTMASK_BAYESN_EPSILON) {
-        gsl_vector * nu = sample_nu(BAYESN_MODEL_INFO.n_lam_knots,
-                BAYESN_MODEL_INFO.n_tau_knots);
-        BAYESN_MODEL_INFO.EPSILON = sample_epsilon(BAYESN_MODEL_INFO.n_lam_knots,
-                BAYESN_MODEL_INFO.n_tau_knots, nu, BAYESN_MODEL_INFO.L_Sigma_epsilon);
+        gsl_vector * nu = sample_nu(BAYESN_MODEL_INFO.n_lam_knots
+                                    ,BAYESN_MODEL_INFO.n_tau_knots);
+
+        BAYESN_MODEL_INFO.EPSILON = sample_epsilon(BAYESN_MODEL_INFO.n_lam_knots
+                                                   ,BAYESN_MODEL_INFO.n_tau_knots, nu
+                                                   ,BAYESN_MODEL_INFO.L_Sigma_epsilon);
         gsl_vector_free(nu);
     }
     // sample DELTAM
     if (ENABLE_SCATTER_BAYESN & OPTMASK_BAYESN_DELTAM) {
         BAYESN_MODEL_INFO.DELTAM = BAYESN_MODEL_INFO.SIGMA0*getRan_Gauss(1);
     }
-}
+} // end genSCATTER_BAYESN()
 
+// =====================================================

--- a/src/genmag_BAYESN.c
+++ b/src/genmag_BAYESN.c
@@ -43,11 +43,10 @@ Each sample counts as 0.01 seconds.
 // #include "sntools_genSmear.h" // Aug 30 2019
 
 // ============ MANGLED FORTRAN FUNCTIONS =============
-// GN - I think we will likely need these - copied from bayesn
 int init_genmag_bayesn__( char *model_version, char *model_extrap, int *optmask) {
-  int istat;
-  istat = init_genmag_BAYESN ( model_version, model_extrap, *optmask) ;
-  return istat;
+    int istat;
+    istat = init_genmag_BAYESN ( model_version, model_extrap, *optmask) ;
+    return istat;
 }
 
 
@@ -317,7 +316,7 @@ void read_BAYESN_inputs(char *filename)
       last_event = event;
     
       if(event.type != YAML_STREAM_END_EVENT)
-        yaml_event_delete(&event);
+          yaml_event_delete(&event);
     } while(event.type != YAML_STREAM_END_EVENT);
     /* END new code */
 
@@ -341,20 +340,19 @@ void read_BAYESN_inputs(char *filename)
 
     // finally initalize the GSL matrices 
     int k = 0, j;
-    for(i=0; i< BAYESN_MODEL_INFO.n_lam_knots; i++)
+    for (i = 0; i < BAYESN_MODEL_INFO.n_lam_knots; i++)
     {
-        for(j=0; j< BAYESN_MODEL_INFO.n_tau_knots; j++)
+        for (j = 0; j < BAYESN_MODEL_INFO.n_tau_knots; j++)
         {
             k = i*BAYESN_MODEL_INFO.n_tau_knots + j;
             gsl_matrix_set(BAYESN_MODEL_INFO.W0, i, j, W0[k]);
             gsl_matrix_set(BAYESN_MODEL_INFO.W1, i, j, W1[k]);
         }
     }
-    for(i=0; i< BAYESN_MODEL_INFO.n_sig_knots; i++)
+    for (i = 0; i < BAYESN_MODEL_INFO.n_sig_knots; i++)
     {
-        for(j=0; j< BAYESN_MODEL_INFO.n_sig_knots; j++)
+        for (j = 0; j < BAYESN_MODEL_INFO.n_sig_knots; j++)
         {
-
             k = i*BAYESN_MODEL_INFO.n_sig_knots + j;
             gsl_matrix_set(BAYESN_MODEL_INFO.L_Sigma_epsilon, i, j, L_Sigma_epsilon[k]);
         }
@@ -365,7 +363,6 @@ void read_BAYESN_inputs(char *filename)
 } // end read_BAYESN_inputs
 
 int init_genmag_BAYESN(char *MODEL_VERSION, char *MODEL_EXTRAP, int optmask){
-
   // Created by. S.Thorp and G.Narayan
   // Read & initialize BAYESN model.
   //
@@ -373,11 +370,14 @@ int init_genmag_BAYESN(char *MODEL_VERSION, char *MODEL_EXTRAP, int optmask){
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // Sep 18 2023: 
   //     RK - add MODEL_EXTRAP argument. 
+  // Apr 23 2025:
+  //     ST - update extrapolation behaviour
+  //        - now uses BayeSN's default linear extrap rule for -20<Trest<85
+  //        - uses flux=0 for Trest<-20 and SNANA linear extrap for Trest>85
 
-  // To Do:
+  // Old To Dos (from RK?):
   // -  Implement MODEL_EXTRAP following logic in genmag_SALT2.c
   // -  make sure that default modelflux_extrap(...) is called correctly.
-  //
 
     int  ised;
     int  retval = 0   ;
@@ -420,66 +420,63 @@ int init_genmag_BAYESN(char *MODEL_VERSION, char *MODEL_EXTRAP, int optmask){
     }
     // print the scatter flag we ended up with
     printf("ENABLE_SCATTER_BAYESN flag is %d (DELTAM %scluded; EPSILON %scluded)\n", 
-            ENABLE_SCATTER_BAYESN, (ENABLE_SCATTER_BAYESN & 4) ? "in" : "ex", (ENABLE_SCATTER_BAYESN & 2) ? "in" : "ex");
+            ENABLE_SCATTER_BAYESN, 
+            (ENABLE_SCATTER_BAYESN & 4) ? "in" : "ex",
+            (ENABLE_SCATTER_BAYESN & 2) ? "in" : "ex"
+          );
     
-
-    // GN - there is one of these further below but unsure yet how RK wants us to use these
-
     // this loads all the BAYESN model components into the BAYESN_MODEL_INFO struct
-    // HACK HACK HACK
     char version[60];
     extract_MODELNAME(MODEL_VERSION, BAYESN_MODELPATH, version);
     char yaml_file[MXPATHLEN];
     sprintf(yaml_file, "%s/BAYESN.YAML", BAYESN_MODELPATH);
     read_BAYESN_inputs(yaml_file);
 
-    // HACK HACK HACK  (RK - at least allow it to work on any cluster using
-    // $SNDATA_ROOT path)
-        // xxx mark  char SED_filepath[] = "/global/cfs/cdirs/lsst/groups/TD/SN/SNANA/SNDATA_ROOT/snsed/Hsiao07.dat";
     char SED_filepath[MXPATHLEN];
     sprintf(SED_filepath,"%s/snsed/Hsiao07.dat", getenv("SNDATA_ROOT") );
 
     int istat, nflux_nan;
     SEDMODEL_FLUX_DEF *S0 = &BAYESN_MODEL_INFO.S0;
     malloc_SEDFLUX_SEDMODEL(S0,0,0,0);
-    double Trange[2] = {BAYESN_MODEL_INFO.tau_knots[0], 
-                        BAYESN_MODEL_INFO.tau_knots[BAYESN_MODEL_INFO.n_tau_knots-1]};
+    
+    // Define time and phase ranges of BAYESN validity (used to load in Hsiao)
+    // ST - I've modified this to load in the full base template
+    //      Tlower = -20.0, hardcoded as this is the lower edge of Hsiao07
+    //      Tupper =  85.0, hardcoded as this is the upper edge of Hsiao07
+    double Tlower    = -20.0 ; // formerly BAYESN_MODEL_INFO.tau_knots[0]
+    double Tupper    =  85.0 ; // formerly BAYESN_MODEL_INFO.tau_knots[BAYESN_MODEL_INFO.n_tau_knots-1] ;
+    double Trange[2] = {Tlower, Tupper};
     double Lrange[2] = {BAYESN_MODEL_INFO.lam_knots[0], 
                         BAYESN_MODEL_INFO.lam_knots[BAYESN_MODEL_INFO.n_lam_knots-1]};
     
     istat = rd_sedFlux(SED_filepath, "Hsiao Template", Trange, Lrange
-		       ,MXBIN_DAYSED_SEDMODEL, MXBIN_LAMSED_SEDMODEL, 0
-		       ,&S0->NDAY, S0->DAY, &S0->DAYSTEP
-		       ,&S0->NLAM, S0->LAM, &S0->LAMSTEP
-		       ,S0->FLUX,  S0->FLUXERR
-		       ,&nflux_nan);
+                       ,MXBIN_DAYSED_SEDMODEL, MXBIN_LAMSED_SEDMODEL, 0
+                       ,&S0->NDAY, S0->DAY, &S0->DAYSTEP
+                       ,&S0->NLAM, S0->LAM, &S0->LAMSTEP
+                       ,S0->FLUX,  S0->FLUXERR
+                       ,&nflux_nan);
 
     if ( NFILT_SEDMODEL == 0 ) {
-      sprintf(c1err,"No filters defined ?!?!?!? " );
-      sprintf(c2err,"Need to call init_filter_SEDMODEL");
-      errmsg(SEV_FATAL, 0, fnam, c1err, c2err); 
+        sprintf(c1err,"No filters defined ?!?!?!? " );
+        sprintf(c2err,"Need to call init_filter_SEDMODEL");
+        errmsg(SEV_FATAL, 0, fnam, c1err, c2err); 
     }
 
-    //ABORT_on_LAMRANGE_ERROR = ( OPTMASK & OPTMASK_BAYESN_ABORT_LAMRANGE ) ;
     filtdump_SEDMODEL();
 
     SEDMODEL.LAMMIN_ALL = BAYESN_MODEL_INFO.lam_knots[0] ;  // rest-frame SED range
     SEDMODEL.LAMMAX_ALL = BAYESN_MODEL_INFO.lam_knots[BAYESN_MODEL_INFO.n_lam_knots-1] ;
-    
-    // 20230911 - GSN - update filter centers to be defined by the YAML files, rather than use this heuristic
-    // SEDMODEL.RESTLAMMIN_FILTERCEN =  SEDMODEL.LAMMIN_ALL + 1200.0 ; // rest-frame central wavelength range
-    // SEDMODEL.RESTLAMMAX_FILTERCEN =  SEDMODEL.LAMMAX_ALL - 1200.0 ;
     SEDMODEL.RESTLAMMIN_FILTERCEN =  BAYESN_MODEL_INFO.l_filter_cen_min ; // rest-frame central wavelength range
     SEDMODEL.RESTLAMMAX_FILTERCEN =  BAYESN_MODEL_INFO.l_filter_cen_max ;
 
-    if (VERBOSE_BAYESN > 0)
-    {
-        printf("DEBUG: LIMITS OF FILTER CENTRAL WAVELENGTH: %.1f, %.1f\n", SEDMODEL.RESTLAMMIN_FILTERCEN
-            , SEDMODEL.RESTLAMMAX_FILTERCEN);
-        printf("DEBUG: LIMITS OF SED WAVELENGTH: %.1f, %.1f\n", SEDMODEL.LAMMIN_ALL, SEDMODEL.LAMMAX_ALL);
+    if ( VERBOSE_BAYESN > 0 ) {
+        printf("DEBUG: LIMITS OF FILTER CENTRAL WAVELENGTH: %.1f, %.1f\n",
+                SEDMODEL.RESTLAMMIN_FILTERCEN, SEDMODEL.RESTLAMMAX_FILTERCEN);
+        printf("DEBUG: LIMITS OF SED WAVELENGTH: %.1f, %.1f\n",
+                SEDMODEL.LAMMIN_ALL, SEDMODEL.LAMMAX_ALL);
     }
 
-    //compute the inverse KD matrices and J_lam (SHOULD THIS BE DONE HERE??)
+    //compute the inverse KD matrices and J_lam 
     BAYESN_MODEL_INFO.KD_tau = invKD_irr(BAYESN_MODEL_INFO.n_tau_knots,
             BAYESN_MODEL_INFO.tau_knots);
     BAYESN_MODEL_INFO.KD_lam = invKD_irr(BAYESN_MODEL_INFO.n_lam_knots,
@@ -493,7 +490,7 @@ int init_genmag_BAYESN(char *MODEL_VERSION, char *MODEL_EXTRAP, int optmask){
     // invoked in snlc_sim
     // added by ST on Mar 22 2024 (sorry)
     BAYESN_MODEL_INFO.EPSILON = gsl_matrix_alloc(BAYESN_MODEL_INFO.n_lam_knots,
-            BAYESN_MODEL_INFO.n_tau_knots);
+                                                 BAYESN_MODEL_INFO.n_tau_knots);
     gsl_matrix_set_zero(BAYESN_MODEL_INFO.EPSILON);
 
     // init _LAST variables for extinction storage
@@ -505,22 +502,22 @@ int init_genmag_BAYESN(char *MODEL_VERSION, char *MODEL_EXTRAP, int optmask){
     //debugexit(fnam);
     fflush(stdout);
     return 0;
+
 } // end init_genmag_BAYESN
 
 // =====================================================
 void genmag_BAYESN(
-		  int OPTMASK     // (I) bit-mask of options (LSB=0)
-		  ,int ifilt_obs  // (I) absolute filter index
-		  ,double *parList_SN   // DLMAG, THETA, AV, RV
-		  ,double mwebv   // (I) Galactic extinction: E(B-V)
-		  ,double z       // (I) Supernova redshift
-		  ,int    Nobs         // (I) number of epochs
-		  ,double *Tobs_list   // (I) list of Tobs (w.r.t peakMJD) 
-		  ,double *magobs_list  // (O) observed mag values
-		  ,double *magerr_list  // (O) model mag errors
-		  ) {
+         int     OPTMASK      // (I) bit-mask of options (LSB=0)
+        ,int     ifilt_obs    // (I) absolute filter index
+        ,double *parList_SN   // (I) DLMAG, THETA, AV, RV
+        ,double  mwebv        // (I) Galactic extinction: E(B-V)
+        ,double  z            // (I) Supernova redshift
+        ,int     Nobs         // (I) number of epochs
+        ,double *Tobs_list    // (I) list of Tobs (w.r.t peakMJD) 
+        ,double *magobs_list  // (O) observed mag values
+        ,double *magerr_list  // (O) model mag errors
+    ) {
 
-    //bool dumpsed = false;
     double DLMAG = parList_SN[0] ;
     double THETA = parList_SN[1] ;
     double AV    = parList_SN[2] ;
@@ -528,47 +525,49 @@ void genmag_BAYESN(
 
     int     OPT_COLORLAW     = MWXT_SEDMODEL.OPT_COLORLAW;
     double *PARLIST_COLORLAW = MWXT_SEDMODEL.PARLIST_COLORLAW;
-    double z1, meanlam_obs,  meanlam_rest, ZP, PARDUM=0.0 ; 
-    double t0, t1, f0, f1, flux ;
+    double  z1, meanlam_obs, meanlam_rest, ZP, PARDUM=0.0 ; 
+    double  t0, t1, f0, f1, flux ;
 
-    int MEMD = sizeof(double)*Nobs ;
-    double *flux_list  = malloc(MEMD); // RK
-    double *Trest_list = malloc(MEMD); 
-    int    *extrap_flag = malloc(MEMD); 
+    int     MEMD        = sizeof(double)*Nobs;
+    double *flux_list   = malloc(MEMD); // RK
+    double *Trest_list  = malloc(MEMD); 
+    int    *extrap_flag = malloc(MEMD);  
+    int    *preexp_flag = malloc(MEMD); // ST
 
-    char *cfilt;
-    int ifilt = 0, i, o ; 
+    char   *cfilt ;
+    int     ifilt = 0, i, o ; 
     
-    //SHOULD I BE DECLARING THESE HERE??
-    gsl_matrix * J_tau; // for time interpolation
-    gsl_matrix * W = gsl_matrix_alloc(BAYESN_MODEL_INFO.n_lam_knots,
-            BAYESN_MODEL_INFO.n_tau_knots); // for W0 + THETA*W1 + EPSILON
-    gsl_matrix * WJ_tau = gsl_matrix_alloc(BAYESN_MODEL_INFO.n_lam_knots,
-            Nobs); //to store matrix product W * J_tau
-    gsl_vector_view j_lam; //to store a row of J_lam
-    gsl_vector * jWJ = gsl_vector_alloc(Nobs);
+    // allocate matrices for the spline operations
+    gsl_vector_view  j_lam;
+    gsl_matrix      *J_tau;
+    gsl_matrix      *W       = gsl_matrix_alloc(BAYESN_MODEL_INFO.n_lam_knots,
+                                                BAYESN_MODEL_INFO.n_tau_knots);
+    gsl_matrix      *WJ      = gsl_matrix_alloc(BAYESN_MODEL_INFO.n_lam_knots, Nobs);
+    gsl_vector      *jWJ     = gsl_vector_alloc(Nobs);
 
-    int nlam_filt, ilam_filt, nlam_model, ilam_model_blue, ilam_model_red ;
-    double *lam_filt_array, lamstep_filt ;
-    double *trans_filt_array;
+    int     nlam_filt, ilam_filt;
+    int     nday_model, nlam_model, ilam_model_blue, ilam_model_red ;
+    double *lam_filt_array, lamstep_filt, *trans_filt_array;
     double *lam_model_array, *day_model_array;
-    double mag, lamstep_model, daystep_model, dlam_tmp, dday_tmp;
-    bool   USE_TABLE_XTMW   = true ;
-    bool   USE_TABLE_XThost = true ;
-    char fnam[] = "genmag_BAYESN";
+    double  mag, lamstep_model, daystep_model, dlam_tmp, dday_tmp;
+    
+    bool    USE_TABLE_XTMW   = true ;
+    bool    USE_TABLE_XThost = true ;
+    char    fnam[]           = "genmag_BAYESN";
 
     // ------- BEGIN -----------
     // translate absolute filter index into sparse index
     ifilt = IFILTMAP_SEDMODEL[ifilt_obs] ;
     z1    = 1. + z ;
 
-
     // init a few things for each obs
-    for(o=0; o<Nobs; o++)  {  
-      Trest_list[o]  = Tobs_list[o]/z1;  
-      flux_list[o]   = 0.0 ;
-      magobs_list[o] = MAG_UNDEFINED ;  //Set magnitudes to undefined
-      extrap_flag[o] = false ;
+    for (o=0; o<Nobs; o++)  {  
+        Trest_list[o]  = Tobs_list[o]/z1;  
+        flux_list[o]   = 0.0 ;
+        magobs_list[o] = MAG_UNDEFINED ;    //Set magnitudes to undefined
+        magerr_list[o] = MAGERR_UNDEFINED ; //Set magerr to undefined
+        extrap_flag[o] = false ;
+        preexp_flag[o] = false ;
     }
 
     // filter info for this "ifilt"
@@ -592,63 +591,25 @@ void genmag_BAYESN(
     trans_filt_array = FILTER_SEDMODEL[ifilt].transSN;
     lamstep_filt     = FILTER_SEDMODEL[ifilt].lamstep;
 
-    // get the SN-model wavelengths
+    // get the SN-model wavelengths and times
     nlam_model       = BAYESN_MODEL_INFO.S0.NLAM;
+    nday_model       = BAYESN_MODEL_INFO.S0.NDAY;
     lam_model_array  = BAYESN_MODEL_INFO.S0.LAM;
     day_model_array  = BAYESN_MODEL_INFO.S0.DAY;
     lamstep_model    = BAYESN_MODEL_INFO.S0.LAMSTEP; // RK
     daystep_model    = BAYESN_MODEL_INFO.S0.DAYSTEP; // RK
 
-    /* xxx RK mark delete slow code
-    // project the model into the observer frame 
-    // get the rest-frame model wavelengths that overlap with the filter 
-    ilam_blue = 0;
-    while (z1*lam_model_array[ilam_blue] <= lam_filt_array[0])
-       { ilam_blue++;    }
-    ilam_red = nlam_model - 1;
-    while (z1*lam_model_array[ilam_red] >= lam_filt_array[nlam_filt-1]) 
-       { ilam_red--;    }
-       xxxxxxx end mark xxxxxx */
-
     // compute ilam_model_blue[red] instead of brute-force search (RK)
     dlam_tmp = lam_filt_array[0] - z1*lam_model_array[0];
     ilam_model_blue = (int)( dlam_tmp / (z1*lamstep_model) ) + 1 ; // RK
-
     dlam_tmp = lam_filt_array[nlam_filt-1] - z1*lam_model_array[0];
-    ilam_model_red = (int)( dlam_tmp / (z1*lamstep_model) ) ; // RK
+    ilam_model_red  = (int)( dlam_tmp / (z1*lamstep_model) ) ; // RK
 
-    // - - - - - - - -
     // compute the matrix for time interpolation
     J_tau = spline_coeffs_irr(Nobs, BAYESN_MODEL_INFO.n_tau_knots,
-            Trest_list, BAYESN_MODEL_INFO.tau_knots, BAYESN_MODEL_INFO.KD_tau);
+              Trest_list, BAYESN_MODEL_INFO.tau_knots, BAYESN_MODEL_INFO.KD_tau);
 
-    // deal with epsilon
-    // relocated to genEPSILON_BAYESN (Mar 22 2024)
-    /*
-    gsl_matrix * EPSILON = gsl_matrix_alloc(BAYESN_MODEL_INFO.n_lam_knots,
-            BAYESN_MODEL_INFO.n_tau_knots);
-    gsl_matrix_set_zero(EPSILON);
-    if (ENABLE_SCATTER_BAYESN) {
-        gsl_vector * nu = sample_nu(BAYESN_MODEL_INFO.n_lam_knots,
-                BAYESN_MODEL_INFO.n_tau_knots);
-        EPSILON = sample_epsilon(BAYESN_MODEL_INFO.n_lam_knots,
-                BAYESN_MODEL_INFO.n_tau_knots, nu, BAYESN_MODEL_INFO.L_Sigma_epsilon);
-        gsl_vector_free(nu);
-    }
-    */
-
-    /* xxx mark delete Jun 19 2023 RK
-    // compute W0 + theta*W1 (SHOULD THIS BE DONE HERE??)
-    // also, this seems utterly unhinged as a way of computing this
-    gsl_matrix_set_zero(W);
-    gsl_matrix_add(W, BAYESN_MODEL_INFO.W1);
-    gsl_matrix_scale(W, THETA);
-    gsl_matrix_add(W, BAYESN_MODEL_INFO.W0);
-    xxxx end mark xxxx */
-
-    // xxx RK Jun 18 2023 - the above gsl_matrix commands is inefficient
-    //       because there are 4 explicit matrix loops. The code here does the
-    //       same computation with 1 matrix loop:
+    // compute W0 + THETA*W1 + EPSILON
     int wx, wy;
     int nx = BAYESN_MODEL_INFO.n_lam_knots;
     int ny = BAYESN_MODEL_INFO.n_tau_knots;
@@ -657,16 +618,14 @@ void genmag_BAYESN(
             double W0_val = gsl_matrix_get(BAYESN_MODEL_INFO.W0, wx, wy) ;
             double W1_val = gsl_matrix_get(BAYESN_MODEL_INFO.W1, wx, wy) ;
             double EP_val = gsl_matrix_get(BAYESN_MODEL_INFO.EPSILON, wx, wy);
-	        double W_val  = W0_val + THETA * W1_val + EP_val;
+            double W_val  = W0_val + THETA * W1_val + EP_val;
             gsl_matrix_set(W, wx,wy, W_val);
          }
     }
-    //    xxxxxx */
 
-    // - - - - - - - - - - - - - - 
     // compute W * J_tau^T
-    gsl_matrix_set_zero(WJ_tau);
-    gsl_blas_dgemm(CblasNoTrans, CblasTrans, 1.0, W, J_tau, 0.0, WJ_tau);
+    gsl_matrix_set_zero(WJ);
+    gsl_blas_dgemm(CblasNoTrans, CblasTrans, 1.0, W, J_tau, 0.0, WJ);
 
     // interpolate the filter wavelengths on to the model in the observer frame
     // usually this is OK because the filters are more coarsely defined than the model
@@ -677,210 +636,158 @@ void genmag_BAYESN(
     double this_lam, lam_model ;
     double this_trans, tr0, tr1, frac ;
     double eA_lam_MW, eA_lam_host; // store MW and host dust law at current wl
-    double eW, S0_lam; //To store other SED  bits
+    double eW, S0_lam; // store other SED  bits
 
-    for(q_lam = ilam_model_blue; q_lam < ilam_model_red; q_lam++) {
+    // loop over model wavelengths within the filter
+    for (q_lam = ilam_model_blue; q_lam < ilam_model_red; q_lam++) {
 
-      lam_model  = lam_model_array[q_lam]; // rest-frame model lam
-      this_lam   = lam_model_array[q_lam]*z1; // obs-frame
+        lam_model  = lam_model_array[q_lam]; // rest-frame model lam
+        this_lam   = lam_model_array[q_lam]*z1; // obs-frame
 
-      // RK - get lam-index for filter
-      ilam_filt   = (int)((this_lam - lam_filt_array[0])/lamstep_filt);
-      if ( ilam_filt < 0 || ilam_filt >= nlam_filt ) {
-	sprintf(c1err,"Invalid ilam_filt=%d", ilam_filt);
-	sprintf(c2err,"Nlam_filt=%d for %s lam=%f ", 
-		nlam_filt, cfilt, this_lam);
-	errmsg(SEV_FATAL, 0, fnam, c1err, c2err); 
-      }
+        // RK - get lam-index for filter
+        ilam_filt   = (int)((this_lam - lam_filt_array[0])/lamstep_filt);
+        if ( ilam_filt < 0 || ilam_filt >= nlam_filt ) {
+            sprintf(c1err,"Invalid ilam_filt=%d", ilam_filt);
+            sprintf(c2err,"Nlam_filt=%d for %s lam=%f ", 
+                    nlam_filt, cfilt, this_lam);
+            errmsg(SEV_FATAL, 0, fnam, c1err, c2err); 
+        }
 
-
-      // for filter transmission, take advantage of fixed lamstep and 
-      // do explicit interpolation that is much faster than interp_1DFUN util
-      // (for slight speed improvement, create this_trans_map[ifilt][q_lam]
-      //  in init_genmag_BAYESN)
-      if ( ilam_filt < nlam_filt-1 ) {
-	tr0  = trans_filt_array[ilam_filt];
-	tr1  = trans_filt_array[ilam_filt+1];
-	frac = ( this_lam - lam_filt_array[ilam_filt] ) / lamstep_filt;
-	this_trans = tr0 + frac*(tr1-tr0);
-      }
-      else {
-	this_trans = trans_filt_array[ilam_filt];
-      }
-      /* xxxxxxxxx RK: mark delete [too slow] xxxxxxxxxxxx
-            this_trans = interp_1DFUN(OPT_INTERP, this_lam, nlam_filt, 
-      			lam_filt_array, trans_filt_array, fnam);
-      xxxxxxxx end mark xxxxxx */
-
-
-
-      // super weird computation
-      // this finds a vector of length Nobs, giving the SED at the
-      // current wavelength for all observations
-      // basically j_lam * W * J_tau^T
-      //
+        // for filter transmission, take advantage of fixed lamstep and 
+        // do explicit interpolation that is much faster than interp_1DFUN util
+        // (for slight speed improvement, create this_trans_map[ifilt][q_lam]
+        //  in init_genmag_BAYESN)
+        if ( ilam_filt < nlam_filt-1 ) {
+            tr0  = trans_filt_array[ilam_filt];
+            tr1  = trans_filt_array[ilam_filt+1];
+            frac = ( this_lam - lam_filt_array[ilam_filt] ) / lamstep_filt;
+            this_trans = tr0 + frac*(tr1-tr0);
+        } else {
+            this_trans = trans_filt_array[ilam_filt];
+        }
       
-      gsl_vector_set_zero(jWJ);
+        // j_lam * W * J_tau^T
+        gsl_vector_set_zero(jWJ);
+        j_lam = gsl_matrix_row(BAYESN_MODEL_INFO.J_lam, q_lam);
+        gsl_blas_dgemv(CblasTrans, 1.0, WJ, &j_lam.vector, 0.0, jWJ);
+
+        // get MW extinction
+        if ( USE_TABLE_XTMW  ) {
+            eA_lam_MW = SEDMODEL_TABLE_MWXT_FRAC[ifilt][ilam_filt] ; // RK
+        } else {
+            double RV_MW = MWXT_SEDMODEL.RV;
+            double AV_MW = RV_MW * mwebv;
+            double XTMAG_MW = GALextinct(RV_MW, AV_MW, this_lam,
+                                         OPT_COLORLAW, PARLIST_COLORLAW, fnam);
+            eA_lam_MW = pow(10.0, -0.4*XTMAG_MW);
+        }
+
+        // get host extinction
+        if ( USE_TABLE_XThost ) {
+            eA_lam_host = SEDMODEL_TABLE_HOSTXT_FRAC[ifilt][ilam_filt]; // RK
+        } else {
+            double XTMAG_host = GALextinct(RV, AV, lam_model,
+                                           OPT_COLORLAW, PARLIST_COLORLAW, fnam );
+            eA_lam_host = pow(10.0, -0.4*XTMAG_host);
+        }
       
-      j_lam = gsl_matrix_row(BAYESN_MODEL_INFO.J_lam, q_lam);
-        
-      // GSN - 20230602 - J_lam matches - compare in restframe
-      //printf("DEBUG lam_model: %.2f     lam filt: %.2f     j_lam: %.5f\n",lam_model[q], this_lam, gsl_vector_get(&j_lam.vector, 0));
-      gsl_blas_dgemv(CblasTrans, 1.0, WJ_tau, &j_lam.vector, 0.0, jWJ);
+        // loop over observations and accumulate the contribution of the
+        // current wavelength to the fluxof each observation
+        for (o = 0; o < Nobs; o++) {
+            eW = pow(10.0, -0.4*gsl_vector_get(jWJ, o));
 
-      if ( USE_TABLE_XTMW  ) {
-	eA_lam_MW   = SEDMODEL_TABLE_MWXT_FRAC[ifilt][ilam_filt] ; // RK
-      }
-      else {
-	//GSN - 20230617 - get the right extinction
-	double RV_MW = MWXT_SEDMODEL.RV;
-	double AV_MW = RV_MW * mwebv;
-	// problem: the 99 arg (colorlaw) is hard-wired ??
-	double XTMAG_MW = GALextinct(RV_MW, AV_MW, this_lam, OPT_COLORLAW, PARLIST_COLORLAW, fnam);
-	eA_lam_MW   = pow(10.0, -0.4*XTMAG_MW);
-      }
-	
-      if ( USE_TABLE_XThost ) {
-	eA_lam_host = SEDMODEL_TABLE_HOSTXT_FRAC[ifilt][ilam_filt]; // RK
-      } else {
-	
-	double XTMAG_host = GALextinct(RV, AV, lam_model, OPT_COLORLAW, PARLIST_COLORLAW, fnam );
-	eA_lam_host = pow(10.0, -0.4*XTMAG_host);
-      }
-      
+            // compute day index instead of brute force search (RK)
+            dday_tmp = Trest_list[o] - day_model_array[0] ;
+            if ( dday_tmp >= 0.0 ) {
+                q_day = (int)( dday_tmp / daystep_model) + 1;
+            } else {
+                preexp_flag[o] = true;
+                continue;
+            } // ST - updated logic to add zero flux at pre-explosion 
 
-      /*if (VERBOSE_BAYESN > 0)
-        {
-	printf("DEBUG: eA_lam_MW: %.3f     eA_lam_host: %.3f\n", eA_lam_MW, eA_lam_host);
-        }*/
+            if ( q_day >= BAYESN_MODEL_INFO.S0.NDAY ) { // RK
+                extrap_flag[o] = true;
+                continue;
+            } // ST - update logic to give undefined mag beyond Hsiao
 
-      for (o = 0; o < Nobs; o++) {
-            /*if (o < 20){
-	      printf("DEBUG: Trest: %.2f    JWJ:   %.5f\n", Trest_list[o], gsl_vector_get(jWJ, o));
-	      }*/
-	eW = pow(10.0, -0.4*gsl_vector_get(jWJ, o));
+            t1 = BAYESN_MODEL_INFO.S0.DAY[q_day];
+            t0 = BAYESN_MODEL_INFO.S0.DAY[q_day-1];
+            f1 = BAYESN_MODEL_INFO.S0.FLUX[nlam_model*q_day + q_lam];
+            f0 = BAYESN_MODEL_INFO.S0.FLUX[nlam_model*(q_day-1) + q_lam];
 
-	/* xxx mark delete RK 
-	// Seek the first Hsiao timestep above the current obs time
-	q_hsiao = 0;
-	while (day_model_array[q_hsiao] <= Trest_list[o]) { q_hsiao++; }
-	xxxxxxx */
+            S0_lam = (f0*(t1 - Trest_list[o]) + f1*(Trest_list[o] - t0))/(t1 - t0);
 
-	// compute day index instead of brute force search (RK)
-	dday_tmp = Trest_list[o] - day_model_array[0] ;
-	if ( dday_tmp >= 0.0 ) 
-	  { q_day = (int)( dday_tmp / daystep_model) + 1; }
-	else 
-	  { q_day = 0; } // not sure this old logic is correct ??
+            //Increment flux with contribution from this wl
+            flux = this_trans * this_lam * lamstep_model * eA_lam_MW * eA_lam_host * eW * S0_lam;         
+            flux_list[o] += flux ;
 
-	// xxx mark delete RK if (q_hsiao < 0 || q_hsiao >= BAYESN_MODEL_INFO.S0.NDAY){
-	if (q_day < 0 ) {
-	  sprintf(c1err,"Invalid q_day index %d. Valid range is [%d, %d]",
-		  q_day, 0, BAYESN_MODEL_INFO.S0.NDAY);
-	  sprintf(c2err,"z=%.3f Trest=%.1f filt=%s",
-		  z, Trest_list[o], cfilt );
-	  
-	  errmsg(SEV_FATAL, 0, fnam, c1err, c2err); 
-	}
-
-	if ( q_day >= BAYESN_MODEL_INFO.S0.NDAY ) { // RK
-	  q_day = BAYESN_MODEL_INFO.S0.NDAY-1; 
-	  extrap_flag[o] = true;
-	}
-
-	t1 = BAYESN_MODEL_INFO.S0.DAY[q_day];
-	t0 = BAYESN_MODEL_INFO.S0.DAY[q_day-1];
-	f1 = BAYESN_MODEL_INFO.S0.FLUX[nlam_model*q_day + q_lam];
-	f0 = BAYESN_MODEL_INFO.S0.FLUX[nlam_model*(q_day-1) + q_lam];
-
-	// HACK HACK HACK throw Trest at this instead or Tobs
-	S0_lam = (f0*(t1 - Trest_list[o]) + f1*(Trest_list[o] - t0))/(t1 - t0);
-
-	//Increment flux with contribution from this wl
-	flux = this_trans * this_lam * lamstep_model * eA_lam_MW * eA_lam_host * eW * S0_lam; 
-	
-	flux_list[o] += flux ;
-
-	/*if (o == 0 && q == ilam_blue + 10) {
-	  printf("XXX DEBUG Trest %.3f; q %d; this_trans %.6f; this_lam %.3f; d_lam %.3f; eA_lam_MW %.3f; eA_lam_host %.3f; eW %.3f; S0_lam %le\n", Trest_list[o], q, this_trans, this_lam, lamstep_model, eA_lam_MW, eA_lam_host, eW, S0_lam);
-            }*/
-	
-	/*if (o == 0) {
-	  dump_sed_element(sedfile, lam_model[q], eA_lam_MW*eA_lam_host*eW*S0_lam);
-            }*/
-
-      } // end o loop over Nobs bins
+        } // end o loop over Nobs bins
     } // end q loop over lam bins
 
-    // - - - - - - - - - -  - -
-
-    /*if (dumpsed) {
-        fclose(sedfile);
-    }*/
-
-    // GSN - 20230602 - J_tau matrix matches but JWJ does not - J_lam matches (look at rest-wavelengths)
-    /*if (VERBOSE_BAYESN > 0)
-    {
-        printf("DEBUG: Printing J_tau matrix\n");
-	    int crap = print_matrix(stdout, J_tau);
-        printf("-----\n\n\n");
-    }*/
-
-
+    // free up the spline matrices
     gsl_matrix_free(J_tau);
     gsl_matrix_free(W);
-    gsl_matrix_free(WJ_tau);
+    gsl_matrix_free(WJ);
     gsl_vector_free(jWJ);
 
-    double zdum = 2.5*log10(1.0+z);
-    if (VERBOSE_BAYESN > 0)
-    {
-        printf("DEBUG: BAYESN_MODEL_INFO.M0: %.2f   DLMAG: %.2f   ZP: %.2f   THETA: %.2f   AV: %.2f\n", BAYESN_MODEL_INFO.M0, DLMAG, ZP, THETA, AV);
+    if (VERBOSE_BAYESN > 0) {
+        printf("DEBUG: BAYESN_MODEL_INFO.M0: %.2f   DLMAG: %.2f   ZP: %.2f   THETA: %.2f   AV: %.2f\n",
+                BAYESN_MODEL_INFO.M0, DLMAG, ZP, THETA, AV);
     }
 
+    //double hc_local   = hc ; // ST - why do we do this? I've commented it out
+    /* XXX mark delete XXX
+    double Trest_edge     = BAYESN_MODEL_INFO.S0.DAY[BAYESN_MODEL_INFO.S0.NDAY-1] ; // ST - updated 
+    int    EXTRAPFLAG_DMP = 0 ;
+    double flux_edge  ;
+    double slope_flux ; // RK HACK
+    /  XXX end mark    XXX */
 
-    double hc_local = hc;
-    double Trest_edge = 40.0, flux_edge = -9.0, slope_flux ; // RK HACK
+    // loop over observations a second time, and fill out the mag_list
     for (o = 0; o < Nobs; o++) {
+        // ST - I am deprecating the below in favour of BayeSN's inbuilt extrap
+        //    - For things beyond the Hsiao07 base template, return undefined
+        /* XXX mark delete XXX
+        // RK - check extrap flag to allow slop in fitted PEAKMJD
+        // ST - this will be triggered if Trest exceeds the base template
+        //    - updates flux based on SNANA extrapolation rule
+        if ( extrap_flag[o] ) {
+            flux_edge    = flux_list[o];
+            slope_flux   = -flux_edge * 0.05; // dF/dt hack
+            flux         = modelflux_extrap(Trest_list[o], Trest_edge, 
+                                            flux_edge, slope_flux, 
+                                            EXTRAPFLAG_DMP); 
+            flux_list[o] = flux;
+        } // end extrap
+        /  XXX end mark    XXX */
 
-      // RK - check extrap flag to allow slop in fitted PEAKMJD
-      if ( extrap_flag[o] ) {
-	flux_edge  = flux_list[o];
-	slope_flux = -flux_edge * 0.05; // dF/dt hack
-	int    EXTRAPFLAG_DMP = 0 ;
-	flux = modelflux_extrap( Trest_list[o], Trest_edge, 
-				 flux_edge, slope_flux, EXTRAPFLAG_DMP ) ; 
-	flux_list[o] = flux;
-      } // end extrap
-      
+        // updated logic Apr 23 2025
+        // check preexp flag to return MAG=99
+        if ( preexp_flag[o] ) {
+            magobs_list[o] = MAG_ZEROFLUX; //99
+            magerr_list[o] = MAGERR_UNDEFINED;
+        // check extrap flag to return MAG=666
+        } else if ( extrap_flag[o] ) {
+            magobs_list[o] = MAG_UNDEFINED; //666
+            magerr_list[o] = MAGERR_UNDEFINED;
+        // otherwise fill out the magobs list
+        } else {
+            magobs_list[o] = BAYESN_MODEL_INFO.M0 + BAYESN_MODEL_INFO.DELTAM
+                           + DLMAG - 2.5*log10(flux_list[o]/hc) + ZP; 
+            magerr_list[o] = 0.01; // RK 0.1 is too big for LCfit
+        }
+    } // end second o loop over Nobs bins
 
-      magobs_list[o] = 
-	BAYESN_MODEL_INFO.M0 +
-    BAYESN_MODEL_INFO.DELTAM +
-	DLMAG -
-	2.5*log10(flux_list[o]/hc_local) +  // RK
-	ZP; 
-
-      /* xxx
-      printf(" xxx %s: o=%d Trest=%f  flux=%le  flux_edge=%le\n", 
-	     fnam, o, Trest_list[o], flux_list[o], flux_edge);
-      xxxx */
-
-      magerr_list[o] = 0.01; // RK 0.1 is too big for LCfit
-
-    }
-
-
-    if (VERBOSE_BAYESN > 0)    {
-      printf("DEBUG: Printing lightcurve\n");
-      for (o = 0; o < Nobs; o++)         { 
-	printf("%.2f  ",magobs_list[o]);
-      }
-      printf("\n-----\n\n\n");
+    if (VERBOSE_BAYESN > 0) {
+        printf("DEBUG: Printing lightcurve\n");
+        for (o = 0; o < Nobs; o++) { 
+            printf("%.2f  ",magobs_list[o]);
+        }
+        printf("\n-----\n\n\n");
     }
     
     // free memory (RK)
-    free(Trest_list); free(flux_list); free(extrap_flag) ; 
+    free(Trest_list); free(flux_list); free(extrap_flag); free(preexp_flag); 
 
     return;
 
@@ -890,12 +797,12 @@ void genmag_BAYESN(
 // =================================
  
 void genmag_bayesn__(int *OPTMASK, int *ifilt_obs, double *parlist_SN,
-	       	double *mwebv, double *z, int *Nobs,
-	       	double *Tobs_list, double *magobs_list,
-	       	double *magerr_list) {
-	genmag_BAYESN(*OPTMASK, *ifilt_obs, parlist_SN, *mwebv, *z,
-		       	*Nobs, Tobs_list, magobs_list, magerr_list);
-	return;
+                     double *mwebv, double *z, int *Nobs,
+                     double *Tobs_list, double *magobs_list,
+                     double *magerr_list) {
+    genmag_BAYESN(*OPTMASK, *ifilt_obs, parlist_SN, *mwebv, *z,
+                    *Nobs, Tobs_list, magobs_list, magerr_list);
+    return;
 }
 
 void dump_SED_element(FILE * file, double wave, double value) {
@@ -903,160 +810,150 @@ void dump_SED_element(FILE * file, double wave, double value) {
 }
 
 gsl_matrix *invKD_irr(int Nk, double *xk) {
-	//FIXME I'm pretty sure this whole thing could be done better by using 
-	//the GSL tridiagonal solver. This is just a direct port of my python.
-
-	gsl_matrix * K = gsl_matrix_alloc(Nk-2, Nk-2);
-	gsl_matrix * D = gsl_matrix_alloc(Nk-2, Nk);
-	gsl_matrix * M = gsl_matrix_alloc(Nk, Nk);
-
-	gsl_matrix_set_zero(K);
-	gsl_matrix_set_zero(D);
-	gsl_matrix_set_zero(M);
-
-	gsl_matrix_set(K, 0, 0, (xk[2] - xk[0])/3.0);
-	gsl_matrix_set(K, 0, 1, (xk[2] - xk[1])/6.0);
-	gsl_matrix_set(K, Nk-3, Nk-4, (xk[Nk-2] - xk[Nk-3])/6.0);
-	gsl_matrix_set(K, Nk-3, Nk-3, (xk[Nk-1] - xk[Nk-3])/3.0);
-
-	int j, r;
-	for (j=2; j<Nk-2; j++) {
-		r = j - 1;
-		gsl_matrix_set(K, r, r-1, (xk[j] - xk[j-1])/6.0);
-		gsl_matrix_set(K, r, r, (xk[j+1] - xk[j-1])/3.0);
-		gsl_matrix_set(K, r, r+1, (xk[j+1] - xk[j])/6.0);
-	}
-	for (j=1; j<Nk-1; j++) {
-		r = j - 1;
-		gsl_matrix_set(D, r, r, 1.0/(xk[j] - xk[j-1]));
-		gsl_matrix_set(D, r, r+1, -1.0/(xk[j+1] - xk[j]) - 1.0/(xk[j] - xk[j-1]));
-		gsl_matrix_set(D, r, r+2, 1.0/(xk[j+1] - xk[j]));
-	}
-
-	int c, s;
-
-	gsl_permutation * p = gsl_permutation_alloc(Nk-2);
-	gsl_linalg_LU_decomp(K, p, &s);
-
-	for (c=0; c<Nk; c++) {
-		//Solve for 1st to (Nk-2)th elements of cth column of M
-		gsl_vector_view d = gsl_matrix_column(D, c);
-		gsl_vector_view m = gsl_matrix_subcolumn(M, c, 1, Nk-2);
-		gsl_linalg_LU_solve(K, p, &d.vector, &m.vector);
-	}
+    //FIXME I'm pretty sure this whole thing could be done better by using 
+    //the GSL tridiagonal solver. This is just a direct port of my python.
+    
+    gsl_matrix * K = gsl_matrix_alloc(Nk-2, Nk-2);
+    gsl_matrix * D = gsl_matrix_alloc(Nk-2, Nk);
+    gsl_matrix * M = gsl_matrix_alloc(Nk, Nk);
+    
+    gsl_matrix_set_zero(K);
+    gsl_matrix_set_zero(D);
+    gsl_matrix_set_zero(M);
+    
+    gsl_matrix_set(K, 0, 0, (xk[2] - xk[0])/3.0);
+    gsl_matrix_set(K, 0, 1, (xk[2] - xk[1])/6.0);
+    gsl_matrix_set(K, Nk-3, Nk-4, (xk[Nk-2] - xk[Nk-3])/6.0);
+    gsl_matrix_set(K, Nk-3, Nk-3, (xk[Nk-1] - xk[Nk-3])/3.0);
+    
+    int j, r;
+    for (j=2; j<Nk-2; j++) {
+        r = j - 1;
+        gsl_matrix_set(K, r, r-1, (xk[j] - xk[j-1])/6.0);
+        gsl_matrix_set(K, r, r, (xk[j+1] - xk[j-1])/3.0);
+        gsl_matrix_set(K, r, r+1, (xk[j+1] - xk[j])/6.0);
+    }
+    for (j=1; j<Nk-1; j++) {
+        r = j - 1;
+        gsl_matrix_set(D, r, r, 1.0/(xk[j] - xk[j-1]));
+        gsl_matrix_set(D, r, r+1, -1.0/(xk[j+1] - xk[j]) - 1.0/(xk[j] - xk[j-1]));
+        gsl_matrix_set(D, r, r+2, 1.0/(xk[j+1] - xk[j]));
+    }
+    
+    int c, s;
+    
+    gsl_permutation * p = gsl_permutation_alloc(Nk-2);
+    gsl_linalg_LU_decomp(K, p, &s);
+    
+    for (c=0; c<Nk; c++) {
+        //Solve for 1st to (Nk-2)th elements of cth column of M
+        gsl_vector_view d = gsl_matrix_column(D, c);
+        gsl_vector_view m = gsl_matrix_subcolumn(M, c, 1, Nk-2);
+        gsl_linalg_LU_solve(K, p, &d.vector, &m.vector);
+    }
 
     gsl_matrix_free(K);
     gsl_matrix_free(D);
 
-	return M;
+    return M;
 }
 
 // =======================================
 gsl_matrix *spline_coeffs_irr(int N, int Nk, double *x, double *xk, 
-			      gsl_matrix *invKD) {
+                              gsl_matrix *invKD) {
 
-  gsl_matrix * J = gsl_matrix_alloc(N, Nk); 
-  gsl_matrix_set_zero(J);
+    gsl_matrix * J = gsl_matrix_alloc(N, Nk); 
+    gsl_matrix_set_zero(J);
 
-  int i, j, q;
-  double h, a, b, c, d, f, h2, a3, b3;
-  for (i=0; i<N; i++) {
-    if (x[i] > xk[Nk-1]) {
-      h = xk[Nk-1] - xk[Nk-2];
-      a = (xk[Nk-1] - x[i])/h;
-      b = 1.0 - a;
-      f = (x[i] - xk[Nk-1])*h/6.0;
+    int i, j, q;
+    double h, a, b, c, d, f, h2, a3, b3;
+    for (i=0; i<N; i++) {
+        if (x[i] > xk[Nk-1]) {
+            h = xk[Nk-1] - xk[Nk-2];
+            a = (xk[Nk-1] - x[i])/h;
+            b = 1.0 - a;
+            f = (x[i] - xk[Nk-1])*h/6.0;
       
-      gsl_matrix_set(J, i, Nk-2, a);
-      gsl_matrix_set(J, i, Nk-1, b);
-      //FIXME I can probably do this by accessing a row and modifying
-      for (j=0; j<Nk; j++) {
-	gsl_matrix_set(J, i, j, 
-		       gsl_matrix_get(J, i, j) + f*gsl_matrix_get(invKD, Nk-2, j) );
-      }
-    }
-    else if (x[i] < xk[0]) {
-      h = xk[1] - xk[0];
-      b = (x[i] - xk[0])/h;
-      a = 1.0 - b;
-      f = (x[i] - xk[0])*h/6.0;
+            gsl_matrix_set(J, i, Nk-2, a);
+            gsl_matrix_set(J, i, Nk-1, b);
+            //FIXME I can probably do this by accessing a row and modifying
+            for (j=0; j<Nk; j++) {
+                gsl_matrix_set(  J, i, j, gsl_matrix_get(J, i, j)
+                                 + f*gsl_matrix_get(invKD, Nk-2, j)  );
+            }
+        } else if (x[i] < xk[0]) {
+            h = xk[1] - xk[0];
+            b = (x[i] - xk[0])/h;
+            a = 1.0 - b;
+            f = (x[i] - xk[0])*h/6.0;
       
-      gsl_matrix_set(J, i, 0, a);
-      gsl_matrix_set(J, i, 1, b);
-      for (j=0; j<Nk; j++) {
-	gsl_matrix_set(J, i, j, 
-		       gsl_matrix_get(J, i, j) - f*gsl_matrix_get(invKD, 1, j) );
-      }
+            gsl_matrix_set(J, i, 0, a);
+            gsl_matrix_set(J, i, 1, b);
+            for (j=0; j<Nk; j++) {
+                gsl_matrix_set(  J, i, j, gsl_matrix_get(J, i, j)
+                                 - f*gsl_matrix_get(invKD, 1, j)  );
+            }
+        } else {
+            q = 0;
+            while (q < Nk-2 && xk[q+1] <= x[i]) { q++; }
+            h = xk[q+1] - xk[q];
+            a = (xk[q+1] - x[i])/h;
+            b = 1.0 - a;
+
+            a3 = a * a * a ;
+            b3 = b * b * b ;
+            h2 = h * h ;
+            c = ( (a3 - a)/6.0) * h2 ; 
+            d = ( (b3 - b)/6.0) * h2 ; 
+      
+            gsl_matrix_set(J, i, q,   a);
+            gsl_matrix_set(J, i, q+1, b);
+            for (j=0; j<Nk; j++) {
+                gsl_matrix_set(  J, i, j, gsl_matrix_get(J, i, j)
+                                 + c*gsl_matrix_get(invKD, q,   j)
+                                 + d*gsl_matrix_get(invKD, q+1, j)  );
+            }
+        }
     }
-    else {
-      q = 0;
-      while (q < Nk-2 && xk[q+1] <= x[i]) { q++; }
-      h = xk[q+1] - xk[q];
-      a = (xk[q+1] - x[i])/h;
-      b = 1.0 - a;
-
-      // RK - replace pow with explicity multiplication (for speed)
-      a3 = a * a * a ;
-      b3 = b * b * b ;
-      h2 = h * h ;
-      c = ( (a3 - a)/6.0) * h2 ; 
-      d = ( (b3 - b)/6.0) * h2 ; 
-
-      /* xxxxxxx beware that pow function is very slow xxxxxxxxxx
-      // xxx RK mark delete c = ((pow(a, 3) - a)/6.0)*h*h; 
-      // xxx RK mark delete d = ((pow(b, 3) - b)/6.0)*h*h;
-      xxxxxxxxx */
-
-      gsl_matrix_set(J, i, q,   a);
-      gsl_matrix_set(J, i, q+1, b);
-      for (j=0; j<Nk; j++) {
-	gsl_matrix_set(J, i, j, 
-		       gsl_matrix_get(J, i, j) + 
-		       c*gsl_matrix_get(invKD, q,   j) + 
-		       d*gsl_matrix_get(invKD, q+1, j) );
-      }
-    }
-  }
   
-  return J;
+    return J;
 
 } // end spline_coeffs_irr 
 
 // =================================================
 // This function creates a vector of N(0,1) draws
 gsl_vector *sample_nu(int n_lam_knots, int n_tau_knots) {
-  int i;
-  int n_knots = (n_lam_knots-2)*n_tau_knots;
-  gsl_vector * nu = gsl_vector_alloc(n_knots);
-  for (i=0; i<n_knots; i++) {
-    gsl_vector_set(nu, i, getRan_Gauss(1));
-  }
+    int i;
+    int n_knots = (n_lam_knots-2)*n_tau_knots;
+    gsl_vector * nu = gsl_vector_alloc(n_knots);
+    for (i=0; i<n_knots; i++) {
+        gsl_vector_set(nu, i, getRan_Gauss(1));
+    }
     return nu;
 } // end sample_nu
 
 // This function translates a vector of N(0,1) draws into epsilon
 gsl_matrix *sample_epsilon(int n_lam_knots, int n_tau_knots, gsl_vector * nu, gsl_matrix * L_Sigma_epsilon) {
-	gsl_vector * epsilon_vec = gsl_vector_alloc((n_lam_knots-2)*n_tau_knots);
-	gsl_matrix * epsilon_mat = gsl_matrix_alloc(n_lam_knots, n_tau_knots);
+    gsl_vector * epsilon_vec = gsl_vector_alloc((n_lam_knots-2)*n_tau_knots);
+    gsl_matrix * epsilon_mat = gsl_matrix_alloc(n_lam_knots, n_tau_knots);
 
-	gsl_vector_set_zero(epsilon_vec);
-	gsl_matrix_set_zero(epsilon_mat);
+    gsl_vector_set_zero(epsilon_vec);
+    gsl_matrix_set_zero(epsilon_mat);
 
     // Multiply by Cholesky factor
     gsl_blas_dgemv(CblasNoTrans, 1.0, L_Sigma_epsilon, nu, 0.0, epsilon_vec);
 
-	int i, j, k;
-	k = 0;
-	for (j=0; j<n_tau_knots; j++) {
-		for (i=1; i<n_lam_knots-1; i++) {
-			gsl_matrix_set(epsilon_mat, i, j, gsl_vector_get(epsilon_vec, k));
-			k++;
-		}
-	}
+    int i, j, k;
+    k = 0;
+    for (j=0; j<n_tau_knots; j++) {
+        for (i=1; i<n_lam_knots-1; i++) {
+            gsl_matrix_set(epsilon_mat, i, j, gsl_vector_get(epsilon_vec, k));
+            k++;
+        }
+    }
 
-	gsl_vector_free(epsilon_vec);
-
-	return epsilon_mat;
+    gsl_vector_free(epsilon_vec);
+    return epsilon_mat;
 } // end sample_epsilon
 
 // this updates the EPSILON and/or DELTAM value stored in BAYESN_MODEL_INFO
@@ -1080,26 +977,4 @@ void genSCATTER_BAYESN() {
         BAYESN_MODEL_INFO.DELTAM = BAYESN_MODEL_INFO.SIGMA0*getRan_Gauss(1);
     }
 }
-
-// =================================================
-int print_matrix(FILE *f, const gsl_matrix *m) {
-
-  int status, n = 0;
-  size_t i=0;
-  size_t j=0;
-
-  for (i = 0; i < m->size1; i++) {
-    for (j = 0; j < m->size2; j++) {
-      if ( (status = fprintf(f, "%g ", gsl_matrix_get(m, i, j))) < 0 )
-	{ return -1; }
-      n += status;
-    }
-
-    if ((status = fprintf(f, "\n")) < 0)
-      { return -1 ; }
-    n += status;
-  }
-  
-  return n;
-} // end print_matrix
 

--- a/src/genmag_BAYESN.h
+++ b/src/genmag_BAYESN.h
@@ -23,8 +23,6 @@ void genmag_bayesn__(int *OPTMASK, int *ifilt_obs, double *parlist_SN,
 	       	double *Tobs_list, double *magobs_list,
 	       	double *magerr_list);
 
-void dump_SED_element(FILE * file, double wave, double value);
-
 gsl_matrix *invKD_irr(int Nk, double *xk);
 gsl_matrix *spline_coeffs_irr(int N, int Nk, double *x, double *xk, gsl_matrix *invKD);
 gsl_vector *sample_nu(int n_lam_knots, int n_tau_knots);

--- a/src/genmag_BAYESN.h
+++ b/src/genmag_BAYESN.h
@@ -2,83 +2,112 @@
 #include "gsl/gsl_rng.h"
 #include "gsl/gsl_randist.h"
 
-int init_genmag_BAYESN(char *MODEL_VERSION, char *MODEL_EXTRAP, int optmask);
-int init_genmag_bayesn__( char *model_version, char *model_extrap, int *optmask);
-void read_BAYESN_inputs(char *filename);
+// init
+int  init_genmag_BAYESN(
+     char * MODEL_VERSION
+    ,char * MODEL_EXTRAP
+    ,int    optmask
+);
+int  init_genmag_bayesn__(
+     char * model_version
+    ,char * model_extrap
+    ,int  * optmask
+);
+void read_BAYESN_inputs(
+     char * filename
+);
 
+// genmag
 void genmag_BAYESN(
-		  int OPTMASK     // (I) bit-mask of options (LSB=0)
-		  ,int ifilt_obs  // (I) absolute filter index
-		  ,double *parList_SN   // DLMAG, THETA, AV, RV
-		  ,double mwebv   // (I) Galactic extinction: E(B-V)
-		  ,double z       // (I) Supernova redshift
-		  ,int    Nobs         // (I) number of epochs
-		  ,double *Tobs_list   // (I) list of Tobs (w.r.t peakMJD)
-		  ,double *magobs_list  // (O) observer-frame model mag values
-		  ,double *magerr_list  // (O) observer-frame model mag errors
-        );
+     int      OPTMASK      // (I) bit-mask of options (LSB=0)
+    ,int      ifilt_obs    // (I) absolute filter index
+	,double * parList_SN   // (I) DLMAG, THETA, AV, RV
+	,double   mwebv        // (I) Galactic extinction: E(B-V)
+	,double   z            // (I) Supernova redshift
+	,int      Nobs         // (I) number of epochs
+	,double * Tobs_list    // (I) list of Tobs (w.r.t peakMJD)
+	,double * magobs_list  // (O) observer-frame model mag values
+	,double * magerr_list  // (O) observer-frame model mag errors
+);
+void genmag_bayesn__(
+     int    * OPTMASK
+    ,int    * ifilt_obs
+    ,double * parlist_SN
+    ,double * mwebv
+    ,double * z 
+    ,int    * Nobs
+    ,double * Tobs_list
+    ,double * magobs_list
+    ,double * magerr_list
+);
 
-void genmag_bayesn__(int *OPTMASK, int *ifilt_obs, double *parlist_SN,
-	       	double *mwebv, double *z, int *Nobs,
-	       	double *Tobs_list, double *magobs_list,
-	       	double *magerr_list);
-
-gsl_matrix *invKD_irr(int Nk, double *xk);
-gsl_matrix *spline_coeffs_irr(int N, int Nk, double *x, double *xk, gsl_matrix *invKD);
-gsl_vector *sample_nu(int n_lam_knots, int n_tau_knots);
-gsl_matrix *sample_epsilon(int n_lam_knots, int n_tau_knots, gsl_vector * nu, gsl_matrix * L_Sigma_epsilon);
-
+// splines
+gsl_matrix * invKD_irr(
+     int          Nk
+    ,double     * xk
+);
+gsl_matrix * spline_coeffs_irr(
+     int          N
+    ,int          Nk
+    ,double     * x
+    ,double     * xk
+    ,gsl_matrix * invKD
+);
+// intrinsic scatter
+gsl_vector * sample_nu(
+     int          n_lam_knots
+    ,int          n_tau_knots
+);
+gsl_matrix * sample_epsilon(
+     int          n_lam_knots
+    ,int          n_tau_knots
+    ,gsl_vector * nu
+    ,gsl_matrix * L_Sigma_epsilon
+);
 void genSCATTER_BAYESN(); // renamed by ST Sep 14 2024
 
-char BAYESN_MODELPATH[MXPATHLEN];
-int VERBOSE_BAYESN;
-#define OPTMASK_BAYESN_VERBOSE 128
+// model path
+char    BAYESN_MODELPATH[MXPATHLEN];
 
-// ST (14 Sep 2024)
-int ENABLE_SCATTER_BAYESN;
-#define OPTMASK_BAYESN_EPSILON 2 // enable only the non-gray (EPSILON) component of intrinsic scatter
-#define OPTMASK_BAYESN_DELTAM  4 // enable only the gray (DELTAM) component of intrinsic scatter
-#define OPTMASK_BAYESN_SCATTER_ALL 6 // sum of all non-default scatter bits
-#define OPTMASK_BAYESN_SCATTER_DEFAULT 1 // enable all scatter components (default behaviour)
+// optmask bits
+int     VERBOSE_BAYESN;
+#define OPTMASK_BAYESN_VERBOSE         128
+int     ENABLE_SCATTER_BAYESN;             // ST (14 Sep 2024)
+#define OPTMASK_BAYESN_EPSILON         2   // enable only the non-gray (EPSILON) scatter
+#define OPTMASK_BAYESN_DELTAM          4   // enable only the gray (DELTAM) scatter
+#define OPTMASK_BAYESN_SCATTER_ALL     6   // sum of all non-default scatter bits
+#define OPTMASK_BAYESN_SCATTER_DEFAULT 1   // enable all scatter components (default behaviour)
 
+// model structure
 struct {
-   int    n_lam_knots;
-   int    n_tau_knots;
-   int    n_sig_knots;
-
+   int          n_lam_knots;
+   int          n_tau_knots;
+   int          n_sig_knots;
    // variables read from BayeSN model directory
    // variables that control the range of validity of the SED
-   double l_filter_cen_min;
-   double l_filter_cen_max;
-   
-   
+   double       l_filter_cen_min;
+   double       l_filter_cen_max;
    // variables that define the SED 
    // scalars
-   double M0;
-   double SIGMA0;
-   double RV;
-   double TAUA;
-
+   double       M0;
+   double       SIGMA0;
+   double       RV;
+   double       TAUA;
    // vectors
-   double *lam_knots;
-   double *tau_knots;
-
+   double     * lam_knots;
+   double     * tau_knots;
    // matrices
-   gsl_matrix *L_Sigma_epsilon;
-   gsl_matrix *W0;
-   gsl_matrix *W1;
-
+   gsl_matrix * L_Sigma_epsilon;
+   gsl_matrix * W0;
+   gsl_matrix * W1;
    // running epsilon variable (yikes)
-   gsl_matrix *EPSILON;
+   gsl_matrix * EPSILON;
    // running DELTAM variable (double yikes)
-   double DELTAM;
-
+   double       DELTAM;
+   // pre-computed spline matrices
+   gsl_matrix * KD_tau;
+   gsl_matrix * KD_lam;
+   gsl_matrix * J_lam;
    // for the base SED - typically Hsiao
    SEDMODEL_FLUX_DEF S0; 
-
-   // computed quantities
-   gsl_matrix *KD_tau;
-   gsl_matrix *KD_lam;
-   gsl_matrix *J_lam;
-
 } BAYESN_MODEL_INFO;

--- a/src/genmag_BAYESN.h
+++ b/src/genmag_BAYESN.h
@@ -2,9 +2,6 @@
 #include "gsl/gsl_rng.h"
 #include "gsl/gsl_randist.h"
 
-// define pre-processor command to use python interface
-// xxx mark delete (RK) #define USE_BAYESNxxx
-
 int init_genmag_BAYESN(char *MODEL_VERSION, char *MODEL_EXTRAP, int optmask);
 int init_genmag_bayesn__( char *model_version, char *model_extrap, int *optmask);
 void read_BAYESN_inputs(char *filename);
@@ -27,7 +24,6 @@ void genmag_bayesn__(int *OPTMASK, int *ifilt_obs, double *parlist_SN,
 	       	double *magerr_list);
 
 void dump_SED_element(FILE * file, double wave, double value);
-int print_matrix(FILE *f, const gsl_matrix *m);
 
 gsl_matrix *invKD_irr(int Nk, double *xk);
 gsl_matrix *spline_coeffs_irr(int N, int Nk, double *x, double *xk, gsl_matrix *invKD);
@@ -86,9 +82,5 @@ struct {
    gsl_matrix *KD_tau;
    gsl_matrix *KD_lam;
    gsl_matrix *J_lam;
-
-   //double **KD_tau;
-   //double **KD_lam;
-   //double **J_lam;
 
 } BAYESN_MODEL_INFO;


### PR DESCRIPTION
This plausibly fixes #1489 (although @mattgrayling or @bap37 should verify).

I have updated the BayeSN C-code to do the extrapolation (in time) a bit differently. Now, the behaviour should be as follows:
 * Use BayeSN's standard linear extrapolation rule if $-20~\text{d}<T_\text{rest}<85~\text{d}$.
 * Return `MAG_ZEROFLUX` (=99) if $T_\text{rest}<-20~\text{d}$.
 * Return `MAG_UNDEFINED` (=666) if $T_\text{rest}>85~\text{d}$.

The limits of $- 20~\text{d}$ and $+85~\text{d}$ are chosen based on the Hsiao07 template that BayeSN uses as its base. If we change this in the future we will need to revisit the way I've coded this, to check it's still valid. But such a change to the base template would probably be significant enough that we'd end up checking a lot of things are still valid, so I don't think this is a big concern.

Aside from the change to the extrapolation behaviour, I have also done some crazy reformatting / tidying of the C-code. This mostly involves changes to whitespace and comma placement, as well as the deletion of a bunch of ancient comments / code that was marked for deletion. There's probably still room for improvement, and maybe these changes will have even been detrimental to overall readability (which I guess is in the eye of the beholder).

Anyway... I ran regression, and both of the BayeSN tests failed:
```
TASK038_SIMGEN_BAYESN_LSST              :  mis-match (REF != TEST)
	 ==> REF:  Efficiency = 0.3000 +- 0.0324
	 ==> TEST: Efficiency = 0.2650 +- 0.0312
TASK039_SIMFIT_CBAYESN_LSST             :  mis-match (REF != TEST)
	 ==> REF:  THETA-61 = 0.30915 +/- 0.4952E-01(P)
	 ==> TEST: THETA-61 = 0.10636 +/- 0.1001
```
This may mean I messed something up, or it may mean that the new extrapolation behaviour is different in a good way. Until I've gotten to the bottom of that, I have made this PR a draft. If anyone has any ideas about this / wants to run their own tests, please feel free!

The covariance related test also failed, but this may be due to #1499:
```
TASK102_CREATE_COV_DES3YR               :  mis-match (REF != TEST)
	 ==> REF:  det(cov) = -177.5
	 ==> TEST: det(cov) = -inf
```
 