### PR TITLE
Added the ability to dump the volumetric rate

### DIFF
--- a/src/snlc_sim.c
+++ b/src/snlc_sim.c
@@ -1400,6 +1400,7 @@ void set_user_defaults(void) {
   INPUTS.SIMGEN_DUMP_NOISE = 0 ;
   INPUTS.SIMGEN_DUMP_TRAINSALT = 0 ;
   INPUTS.SIMGEN_DUMP_MWCL      = 0 ;
+  INPUTS.SIMGEN_DUMP_RATE      = 0 ;
   
 #ifdef MODELGRID_GEN
   sprintf(GRIDGEN_INPUTS.FORMAT, "%s", "BLANK" );
@@ -4784,6 +4785,10 @@ int parse_input_SIMGEN_DUMP(char **WORDS,int keySource) {
   }
   else if ( keyMatchSim(1, "SIMGEN_DUMP_MWCL", WORDS[0], keySource) ) {
     N++ ; sscanf(WORDS[N] , "%d", &INPUTS.SIMGEN_DUMP_MWCL );
+    return(N);
+  }
+  else if ( keyMatchSim(1, "SIMGEN_DUMP_RATE", WORDS[0], keySource) ) {
+    N++ ; sscanf(WORDS[N] , "%d", &INPUTS.SIMGEN_DUMP_RATE );
     return(N);
   }
 
@@ -15273,6 +15278,62 @@ void wr_SIMGEN_DUMP_TRAINSALT(int OPT_DUMP, SIMFILE_AUX_DEF *SIMFILE_AUX) {
 
   return;
 } // end wr_SIMGEN_DUMP_TRAINSALT
+
+void wr_SIMGEN_DUMP_RATE(int OPT_DUMP, SIMFILE_AUX_DEF *SIMFILE_AUX) {
+// Created Nov 2025 by Cole Meldorf
+//    Invoked by sim input:
+//         SIMGEN_DUMP_RATE: 1
+//        Write volumetric rate versus redshift.
+//        Initial motivation: Needed input to rate fitting model.
+//         
+	double Z0 = INPUTS.GENRANGE_REDSHIFT[0] ;
+        double Z1 = INPUTS.GENRANGE_REDSHIFT[1] ;
+        double rtmp , ztmp ; 
+	FILE *fp ;
+        char *ptrFile = SIMFILE_AUX->DUMP_RATE ;
+	char fnam[] = "wr_SIMGEN_DUMP_RATE" ;
+	// BEGIN
+	
+	if ( INPUTS.SIMGEN_DUMP_RATE <= 0 ) { return; }
+	if ( OPT_DUMP == FLAG_PROCESS_INIT ) {
+
+    		sprintf(BANNER,"Created SIMGEN_DUMP_RATE file " );
+    		print_banner(BANNER);
+
+
+    		// open file and write header
+        	if ( (SIMFILE_AUX->FP_DUMP_RATE = fopen(ptrFile, "wt")) == NULL ) {
+        		sprintf ( c1err, "Cannot open SIMGEN RATE-dump file :" );
+        		sprintf ( c2err," '%s' ", ptrFile );
+                	errmsg(SEV_FATAL, 0, fnam, c1err, c2err);
+                               }
+    
+   	     printf("\t open %s\n", ptrFile );
+             fflush(stdout);
+             fp = SIMFILE_AUX->FP_DUMP_RATE ;
+             fprintf(fp, "# RATE = Volumetric Rate (per year per Mpc^3) w/ H0 = 70.0 \n");
+	     fprintf(fp, "VARNAMES: ROW REDSHIFT RATE \n");
+             ztmp = Z0 ; 
+             int nrow = 0 ;
+             while ( ztmp <= Z1 ) {
+                nrow += 1 ;
+      	     	rtmp = genz_wgt(ztmp,&INPUTS.RATEPAR) ;
+                fprintf(fp, "ROW: %d %.3f %.4le \n", nrow, ztmp, rtmp) ; 
+             	ztmp += 0.01 ;
+    	     }
+  } 
+    
+
+        
+        // Close the file
+	if ( OPT_DUMP == FLAG_PROCESS_END) {
+    		fp = SIMFILE_AUX->FP_DUMP_RATE ;
+    		fclose(SIMFILE_AUX->FP_DUMP_RATE);
+    		printf("  %s\n", ptrFile );     fflush(stdout);
+  }
+	return ; 	
+} // end wr_SIMGEN_DUMP_RATE
+
 
 
 // ***********************************************
@@ -30348,6 +30409,7 @@ void init_simFiles(SIMFILE_AUX_DEF *SIMFILE_AUX) {
   sprintf(SIMFILE_AUX->DUMP_NOISE, "%s.NOISE",       prefix ); // Aug 2024
   sprintf(SIMFILE_AUX->DUMP_SPEC,  "%s.SPEC",        prefix ); // Mar 2024
   sprintf(SIMFILE_AUX->DUMP_MWCL,  "%s.MWCL",        prefix ); // May 2025
+  sprintf(SIMFILE_AUX->DUMP_RATE,  "%s.RATE",        prefix ); // Nov 2025
   sprintf(SIMFILE_AUX->DUMP_TRAINSALT, "%s.TRAINSALT",  prefix ); // Oct 2024  
 
   // Aug 10 2020: for batch mode, write YAML file locally so that
@@ -30386,6 +30448,7 @@ void init_simFiles(SIMFILE_AUX_DEF *SIMFILE_AUX) {
   wr_SIMGEN_DUMP_SPEC(FLAG,SIMFILE_AUX);          // SPEC 
   wr_SIMGEN_DUMP_TRAINSALT(FLAG,SIMFILE_AUX);     // tmax for trainsalt
   wr_SIMGEN_DUMP_MWCL(FLAG,SIMFILE_AUX);          // MWCL amd MAG vs. wavelength
+  wr_SIMGEN_DUMP_RATE(FLAG,SIMFILE_AUX);          // Volumetric Rate vs. z
   wr_VERIFY_SED_TRUE(FLAG, 0, zero, zero, zero );  // SED_TRUE
 
   // - - - - - 
@@ -30579,6 +30642,7 @@ void end_simFiles(SIMFILE_AUX_DEF *SIMFILE_AUX) {
   wr_SIMGEN_DUMP_SPEC(FLAG,SIMFILE_AUX);
   wr_SIMGEN_DUMP_TRAINSALT(FLAG,SIMFILE_AUX);     // tmax for trainsalt  
   wr_SIMGEN_DUMP_MWCL(FLAG,SIMFILE_AUX);          // MW CL vs. wave
+  wr_SIMGEN_DUMP_RATE(FLAG,SIMFILE_AUX);          // Volumetric rate
   wr_VERIFY_SED_TRUE(FLAG, 0, zero, zero, zero);
 
   // copy ZVARATION file to SIM/[VERSION]

--- a/src/snlc_sim.h
+++ b/src/snlc_sim.h
@@ -188,7 +188,8 @@ typedef struct { // SIMFILE_AUX_DEF
   FILE *FP_DUMP_NOISE;  char  DUMP_NOISE[MXPATHLEN] ;  
   FILE *FP_DUMP_SPEC;   char  DUMP_SPEC[MXPATHLEN] ;
   FILE *FP_DUMP_TRAINSALT;  char  DUMP_TRAINSALT[MXPATHLEN] ;  
-  FILE *FP_DUMP_MWCL;   char  DUMP_MWCL[MXPATHLEN] ;  
+  FILE *FP_DUMP_MWCL;   char  DUMP_MWCL[MXPATHLEN] ; 
+  FILE *FP_DUMP_RATE;   char  DUMP_RATE[MXPATHLEN] ; 
   FILE *FP_YAML;        char  YAML[MXPATHLEN] ;  // Aug 10 2020, for submit_batch
   char PATH_FILTERS[MXPATHLEN]; // directory instead of file
 
@@ -1041,10 +1042,12 @@ struct INPUTS {
   bool IS_SIMSED_SIMGEN_DUMP[MXSIMGEN_DUMP];
   int  IFLAG_SIMGEN_DUMPALL ;  // 1 -> dump every generated SN
   int  PRESCALE_SIMGEN_DUMP ;  // prescale on writing to SIMGEN_DUMP file
+       
 
   int  SIMGEN_DUMP_NOISE; // Aug 30 2014: diagnostic dump of noise per obs.
   int  SIMGEN_DUMP_TRAINSALT; // OCt 2024: write aux file with TMAX for trainsalt
   int  SIMGEN_DUMP_MWCL ;     // write aux file with CL-vs.wavelength for all MWCL options
+  int  SIMGEN_DUMP_RATE ;    // Dump volumetric rate versus redshift
 
   // inputs for intrinsic scatter matrix (July 27, 2011)
   int    NCOVMAT_SCATTER ;           // number of non-zero elements
@@ -2271,6 +2274,7 @@ void wr_SIMGEN_DUMP_NOISE(int OPT_DUMP, SIMFILE_AUX_DEF *SIMFILE_AUX,
 void wr_SIMGEN_DUMP_SPEC(int OPT_DUMP, SIMFILE_AUX_DEF *SIMFILE_AUX);
 void wr_SIMGEN_DUMP_TRAINSALT(int OPT_DUMP, SIMFILE_AUX_DEF *SIMFILE_AUX);
 void wr_SIMGEN_DUMP_MWCL(int OPT_DUMP, SIMFILE_AUX_DEF *SIMFILE_AUX);
+void wr_SIMGEN_DUMP_RATE(int OPT_DUMP, SIMFILE_AUX_DEF *SIMFILE_AUX);
 
 void wr_SIMGEN_YAML_SUMMARY(SIMFILE_AUX_DEF *SIMFILE_AUX);
 void rewrite_HOSTLIB_DRIVER(void);


### PR DESCRIPTION
Added a new dump file, SIMGEN_DUMP_RATE, that dumps the volumetric sne rate in zbins of size 0.01