### PR TITLE
add generalized spline library and wire photo-z quantile + logmass-z

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -68,7 +68,7 @@ CC   = gcc
   PROFILEFLAG = 
 
 EXTRA_FLAGS = -O2 #  -Wall   # xxx RESTORE
-#EXTRA_FLAGS = -g -fbounds-check  # valgrind --leak-check=full 
+#EXTRA_FLAGS = -g -fbounds-check  # valgrind --leak-check=full
 
 # check if gcc version is 10 or higher (9.2020)
 GCCVERSION10 := $(shell expr `gcc -dumpversion | cut -f1 -d.` \>= 10)
@@ -712,6 +712,7 @@ $(OBJ)/sntools_zPDF_spline.o : $(SRC)/sntools_zPDF_spline.c $(SRC)/sntools_zPDF_
 $(OBJ)/sntools_spline.o : $(SRC)/sntools_spline.c $(SRC)/sntools_spline.h
 	(cd $(OBJ); \
         $(CC) $(SNCFLAGS) $(IGSL) $(SRC)/sntools_spline.c )
+
 
 
 

--- a/src/snana.F90
+++ b/src/snana.F90
@@ -17367,6 +17367,10 @@
     LOGICAL   :: BIGGER_z
 
     CHARACTER FNAM*20
+
+! external C functions
+    REAL*8, EXTERNAL :: eval_spline_gen
+
 ! ------------- BEGIN ---------------
 
     FNAM = 'SET_SNHOST_QZPHOT'
@@ -17408,15 +17412,23 @@
     if ( STDOUT_UPDATE ) IPRINT = 1
 
     if (DEBUG_FLAG == 28 ) THEN
-       ! REFACTORED  NEWCALL GOES HERE MAY, 2026
-       INDEX_SPLINE = -9
-       CALL init_spline(INDEX_SPLINE_QUANTILE_ZPHOT, NQ, QPROB, QZPHOT,  &
+       ! Use new generalized spline (sntools_spline_gen.c).
+       ! Note arg order: x=QZPHOT (redshift), y=QPROB (percentile) for CDF spline.
+       CALL init_spline(INDEX_SPLINE_QUANTILE_ZPHOT, NQ, QZPHOT, QPROB,  &
             SNLC_CCID(1:ISNLC_LENCCID)    // char(0),  &
             METHOD_SPLINE_QUANTILES(1:LM) // char(0),  &
-            "QUANTILE_ZPHOT" // char(0), &
+            "QUANTILE_ZPHOT" // char(0),  &
             IPRINT, MEAN, STD, IERR, ISNLC_LENCCID, LM)
-       PRINT*, 'XXX DEBUG FLAG = ', DEBUG_FLAG
-       STOP
+       ! diagnostic: confirm new code path was taken and print slot info
+       PRINT*, ' '
+       PRINT*, 'XXX DEBUG_FLAG=28: init_spline_gen returned'
+       PRINT*, 'XXX   CID    = ', SNLC_CCID(1:ISNLC_LENCCID)
+       PRINT*, 'XXX   NQ     = ', NQ
+       PRINT*, 'XXX   IERR   = ', IERR
+       PRINT*, 'XXX   MEAN   = ', MEAN
+       PRINT*, 'XXX   STD    = ', STD
+       CALL dump_spline_gen(INDEX_SPLINE_QUANTILE_ZPHOT)
+       PRINT*, ' '
     else
        ! LEGACY CALL
        CALL init_zPDF_spline(NQ, QPROB, QZPHOT,  &
@@ -17433,6 +17445,79 @@
 
     return
     END SUBROUTINE SET_SNHOST_QZPHOT
+
+! =============================================
+    SUBROUTINE SET_SNHOST_LOGMASS_SPLINE(METHOD_SPLINE, IGAL, &
+                                          LM_MEAN, LM_STD, IERR)
+!
+! Created May 2026 A.Mitra
+! Fit a spline through the per-galaxy logmass(z) grid stored in
+! SNHOSTz_LOGMASS(IGAL), then return the Gaussian-marginalized
+! logmass mean and std using the host photo-z and its uncertainty.
+!
+! Inputs:
+!   METHOD_SPLINE  : interpolation method ("LINEAR","CUBIC","STEFFEN")
+!   IGAL           : sparse host index (1..MXSNHOST)
+! Outputs:
+!   LM_MEAN        : Gaussian-weighted mean logmass
+!   LM_STD         : corresponding standard deviation
+!   IERR           : 0=ok, -1=negative z, -2=non-monotonic z, -9=no data
+
+    USE SNDATCOM
+    USE SNLCINP_NML
+
+    IMPLICIT NONE
+
+    CHARACTER :: METHOD_SPLINE*(*)
+    INTEGER   :: IGAL
+    REAL*8    :: LM_MEAN, LM_STD
+    INTEGER   :: IERR
+
+! local var
+    INTEGER   :: NZ, iz, LM, IPRINT
+    REAL*8    :: Z_LIST(MXBIN_SNHOSTz), LMASS_LIST(MXBIN_SNHOSTz)
+    REAL*8    :: MEAN, STD
+    REAL*8    :: Z_PH, Z_PH_ERR
+
+    CHARACTER FNAM*30
+! ------------- BEGIN ---------------
+
+    FNAM = 'SET_SNHOST_LOGMASS_SPLINE'
+    IERR    = -9
+    LM_MEAN = -9.0D0
+    LM_STD  =  0.0D0
+
+    NZ = SNHOSTz_LOGMASS(IGAL)%NZ
+    if ( NZ <= 0 ) RETURN   ! no logmass grid for this galaxy
+
+    ! copy from TYPE arrays to plain REAL*8 arrays for C call
+    do iz = 1, NZ
+       Z_LIST(iz)    = DBLE( SNHOSTz_LOGMASS(IGAL)%Z_LIST(iz)   )
+       LMASS_LIST(iz)= DBLE( SNHOSTz_LOGMASS(IGAL)%VAL_LIST(iz) )
+    enddo
+
+    LM     = INDEX(METHOD_SPLINE,' ') - 1
+    IPRINT = 0
+    if ( STDOUT_UPDATE ) IPRINT = 1
+
+    ! fit spline through (z, logmass) grid -- DIRECT mode (no "QUANTILE" in name)
+    CALL init_spline(INDEX_SPLINE_LOGMASS_ZGRID, NZ, Z_LIST, LMASS_LIST, &
+         SNLC_CCID(1:ISNLC_LENCCID)  // char(0),  &
+         METHOD_SPLINE(1:LM)         // char(0),  &
+         "LOGMASS_ZGRID"             // char(0),  &
+         IPRINT, MEAN, STD, IERR, ISNLC_LENCCID, LM)
+
+    if ( IERR /= 0 ) RETURN   ! bad z grid; caller handles
+
+    ! Gaussian-marginalized logmass over photo-z uncertainty
+    Z_PH     = DBLE( SNHOST_ZPHOT(IGAL) )
+    Z_PH_ERR = DBLE( SNHOST_ZPHOT_ERR(IGAL) )
+
+    CALL eval_spline_gen_integral(INDEX_SPLINE_LOGMASS_ZGRID, &
+                                  Z_PH, Z_PH_ERR, LM_MEAN, LM_STD)
+
+    return
+    END SUBROUTINE SET_SNHOST_LOGMASS_SPLINE
 
 ! =============================================
     SUBROUTINE SET_SNHOST_ZPHOT()

--- a/src/snlc_fit.F90
+++ b/src/snlc_fit.F90
@@ -4746,15 +4746,15 @@
         ,MUMAX      = 60.      ! max distance mod.
 
 ! functions
-    REAL*8  & 
-         CHI2_PRIOR, CHI2_PRIOR_SNCID_FILE  & 
-        ,PRIOR_ZPULL  & 
-        ,PRIOR_MUPULL  & 
-        ,GET_RV8  & 
+    REAL*8  &
+         CHI2_PRIOR, CHI2_PRIOR_SNCID_FILE  &
+        ,PRIOR_ZPULL  &
+        ,PRIOR_MUPULL  &
+        ,GET_RV8  &
         ,eval_zPDF_spline, DLMAG_REF &
-        ,eval_spline
+        ,eval_spline, eval_spline_gen
 
-    EXTERNAL eval_zPDF_spline, eval_spline
+    EXTERNAL eval_zPDF_spline, eval_spline, eval_spline_gen
 
 ! ------------- BEGIN --------------
 
@@ -4859,10 +4859,10 @@
          ! get the probability at this redshift
 
          if(DEBUG_FLAG == 28) then
-            PROBZ = eval_SPLINE(ZSN)
+            PROBZ = eval_spline_gen(INDEX_SPLINE_QUANTILE_ZPHOT, ZSN)
          else
             PROBZ = eval_zPDF_spline(ZSN)  ! use zPDF from quantiles
-         endif   
+         endif
         if ( PROBZ > 0.0 ) then
            CHI2PRIOR(IPAR_zPHOT) = -2.0*DLOG( PROBZ )
         else

--- a/src/sntools_spline.c
+++ b/src/sntools_spline.c
@@ -1,40 +1,451 @@
-// generalized spline code
+// sntools_spline_gen.c 
+//
+// Generalized multi-instance spline interpolation.
+// See sntools_spline_gen.h for full API documentation.
+//
+// Authors : A. Mitra  (May 2026) -- initial implementation
+// Based on : sntools_zPDF_spline.c  by R. Chen (Jun 2022), R. Kessler 
+
+#include <math.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
 #include <gsl/gsl_errno.h>
-#include <gsl/gsl_spline.h> 
+#include <gsl/gsl_spline.h>
 
 #include "sntools.h"
-#include "sntools_zPDF_spline.h"
+#include "sntools_spline.h"
 
-#include <sys/types.h>
-#include <sys/stat.h>
+// - - - - - - - - - - - - - - - - - - - - - -
+// Module-level storage
 
+SPLINE_GEN_DEF SPLINE_GEN_ARRAY[MXSPLINE_GEN];
 
-void init_spline(int *index, int NVAL, double* x_list, double* y_list, 
-		 char *cid, char *method_spline, char *name, int verbose,
-                      double *mean, double *std_dev, int *error_flag){
-  char fnam[] = "init_spline()";
-  printf("XXX Hello from %s, INDEX = %d, N = %d, name = %s\n",fnam, *index, NVAL, name);
+// Private helpers
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+// First-call zero-initialization of the entire slot array.
+static void _spline_gen_global_init(void) {
+    int i;
+    for (i = 0; i < MXSPLINE_GEN; i++) {
+        SPLINE_GEN_ARRAY[i].initialized = 0;
+        SPLINE_GEN_ARRAY[i].acc         = NULL;
+        SPLINE_GEN_ARRAY[i].spline      = NULL;
+        SPLINE_GEN_ARRAY[i].NVAL        = 0;
+        SPLINE_GEN_ARRAY[i].val_max     = 1.0;
+    }
+    SPLINE_GEN_INIT_DONE = 1;
+}
+
+// Infer evaluation mode from the slot name.
+// Names containing "QUANTILE" use DERIV mode (PDF from CDF derivative).
+// All others use DIRECT mode (plain interpolation).
+static int _get_mode_from_name(const char *name) {
+    if (strstr(name, "QUANTILE") != NULL) { return SPLINE_GEN_MODE_DERIV; }
+    return SPLINE_GEN_MODE_DIRECT;
+}
+
+// Free GSL objects for a slot if they were previously allocated.
+static void _free_spline_slot(SPLINE_GEN_DEF *sp) {
+    if (sp->initialized) {
+        if (sp->spline) { gsl_spline_free(sp->spline);       sp->spline = NULL; }
+        if (sp->acc)    { gsl_interp_accel_free(sp->acc);    sp->acc    = NULL; }
+        sp->initialized = 0;
+    }
+}
+
+// Allocate GSL spline and accelerator for the requested method.
+// Returns 0 on success, -1 on unknown method (caller should abort).
+static int _alloc_gsl_spline(SPLINE_GEN_DEF *sp, int NVAL,
+                              const char *method_spline, const char *cid) {
+    char fnam[] = "_alloc_gsl_spline";
+
+    sp->acc = gsl_interp_accel_alloc();
+
+    if (strcmp(method_spline, METHOD_SPLINE_LINEAR) == 0) {
+        sp->spline = gsl_spline_alloc(gsl_interp_linear, NVAL);
+
+    } else if (strcmp(method_spline, METHOD_SPLINE_CUBIC) == 0) {
+        sp->spline = gsl_spline_alloc(gsl_interp_cspline, NVAL);
+
+    } else if (strcmp(method_spline, METHOD_SPLINE_STEFFEN) == 0) {
+#ifdef GSL_INTERP_STEFFEN
+        sp->spline = gsl_spline_alloc(gsl_interp_steffen, NVAL);
+#else
+        sprintf(c1err, "Compilation does not include STEFFEN method");
+        sprintf(c2err, "Needs GSL >= 2.7  (CID=%s)", cid);
+        errmsg(SEV_FATAL, 0, fnam, c1err, c2err);
+#endif
+    } else {
+        sprintf(c1err, "Unknown method_spline = '%s' for CID=%s", method_spline, cid);
+        sprintf(c2err, "Valid options: %s  %s  %s",
+                METHOD_SPLINE_LINEAR, METHOD_SPLINE_CUBIC, METHOD_SPLINE_STEFFEN);
+        errmsg(SEV_FATAL, 0, fnam, c1err, c2err);
+    }
+    return 0;
+}
+
+// Compute mean and std_dev on a uniform grid over [xmin, xmax].
+//
+// DERIV mode (CDF spline, x=z, y=percentile):
+//   Uses the derivative  P(x) = d[CDF]/dx  as a probability weight.
+//   mean   = integral[ x * P(x) dx ] / integral[ P(x) dx ]   (PDF-weighted mean of x)
+//   std    = sqrt( integral[ (x-mean)^2 * P(x) dx ] / integral[P(x) dx] )
+//   val_max is set to max(P(x)) for later normalization in eval.
+//
+// DIRECT mode (e.g. logmass(z)):
+//   Computes simple mean and std of y over the x grid.
+//   mean   = mean of y(x_i) over the uniform grid
+//   std    = std  of y(x_i) over the uniform grid
+//   val_max is set to max(|y|) (informational; not used in eval).
+//
+static void _compute_stats(SPLINE_GEN_DEF *sp) {
+    int    ix, NBIN = NBIN_SPLINE_GEN;
+    double x, val, sum_wval, sum_w, sum_sq, val_max;
+    double xmin = sp->xmin, xmax = sp->xmax, dx = sp->dx;
+
+    double *store = (double *)malloc((NBIN + 2) * sizeof(double));
+
+    sum_wval = sum_w = val_max = 0.0;
+    ix = 0;
+
+    for (x = xmin; x <= xmax + 0.5 * dx; x += dx) {
+        if (x > xmax) x = xmax;   // clamp last step
+
+        if (sp->mode == SPLINE_GEN_MODE_DERIV) {
+            // weight = PDF(x) = d[CDF]/dx; floor at 0
+            val = gsl_spline_eval_deriv(sp->spline, x, sp->acc);
+            if (val < 0.0) val = 0.0;
+            sum_wval += x * val;   // PDF-weighted sum of x
+            sum_w    += val;
+            if (val > val_max) val_max = val;
+
+        } else {
+            // direct: accumulate y values uniformly
+            val       = gsl_spline_eval(sp->spline, x, sp->acc);
+            sum_wval += val;
+            sum_w    += 1.0;
+            if (fabs(val) > val_max) val_max = fabs(val);
+        }
+        store[ix++] = val;
+    }
+
+    sp->val_max = (val_max > 0.0) ? val_max : 1.0;
+    sp->mean    = (sum_w > 0.0)   ? (sum_wval / sum_w) : 0.0;
+
+    // second pass: standard deviation
+    sum_sq = 0.0;
+    ix = 0;
+    for (x = xmin; x <= xmax + 0.5 * dx; x += dx) {
+        if (x > xmax) x = xmax;
+        double wt = store[ix];
+        double q  = (sp->mode == SPLINE_GEN_MODE_DERIV) ? x : wt;
+        double dq = (sp->mode == SPLINE_GEN_MODE_DERIV) ? wt : 1.0;
+        sum_sq += (q - sp->mean) * (q - sp->mean) * dq;
+        ix++;
+    }
+    sp->std_dev = (sum_w > 0.0 && sum_sq > 0.0) ? sqrt(sum_sq / sum_w) : 0.0;
+
+    free(store);
 }
 
 
-void init_spline__(int *index, int *NVAL, double* x_list, double* y_list, 
-		   char *cid, char *method_spline, char *name, int *verbose,
-                      double *mean, double *std_dev, int *error_flag){
-  init_spline(index, *NVAL,x_list, y_list, cid, method_spline, name, *verbose, mean, std_dev, error_flag);
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Public functions
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+// ============================================================
+void init_spline(int index, int NVAL,
+                     double *x_list, double *y_list,
+                     char *cid, char *method_spline, char *name, int verbose,
+                     double *mean, double *std_dev, int *error_flag) {
+    // See header for full documentation.
+
+    char fnam[] = "init_spline";
+    int  i;
+
+    // one-time global initialization
+    if (!SPLINE_GEN_INIT_DONE) { _spline_gen_global_init(); }
+
+    // ---- validate index ----
+    if (index < 0 || index >= MXSPLINE_GEN) {
+        sprintf(c1err, "index=%d out of range [0, %d]", index, MXSPLINE_GEN - 1);
+        sprintf(c2err, "CID=%s  name=%s", cid, name);
+        errmsg(SEV_FATAL, 0, fnam, c1err, c2err);
+    }
+
+    // ---- validate NVAL ----
+    if (NVAL < 2) {
+        sprintf(c1err, "NVAL=%d is too small (need >= 2)", NVAL);
+        sprintf(c2err, "CID=%s  name=%s", cid, name);
+        errmsg(SEV_FATAL, 0, fnam, c1err, c2err);
+    }
+
+    // ---- init outputs ----
+    *error_flag = 0;
+    *mean       = 0.0;
+    *std_dev    = 0.0;
+
+    // ---- check x is strictly increasing ----
+    for (i = 1; i < NVAL; i++) {
+        if (x_list[i] <= x_list[i - 1]) {
+            if (x_list[i] < 0.0) { *error_flag = -1; }
+            else                  { *error_flag = -2; }
+            if (verbose) {
+                printf(" WARNING %s: x_list not strictly increasing at i=%d"
+                       " (x[%d]=%g, x[%d]=%g) for CID=%s name=%s\n",
+                       fnam, i, i-1, x_list[i-1], i, x_list[i], cid, name);
+                fflush(stdout);
+            }
+            return;
+        }
+    }
+
+    // ---- free previous allocation for this slot ----
+    _free_spline_slot(&SPLINE_GEN_ARRAY[index]);
+
+    SPLINE_GEN_DEF *sp = &SPLINE_GEN_ARRAY[index];
+
+    // ---- store metadata ----
+    snprintf(sp->name,   sizeof(sp->name),   "%s", name);
+    snprintf(sp->method, sizeof(sp->method), "%s", method_spline);
+    sp->NVAL  = NVAL;
+    sp->mode  = _get_mode_from_name(name);
+    sp->xmin  = x_list[0];
+    sp->xmax  = x_list[NVAL - 1];
+    sp->dx    = (sp->xmax - sp->xmin) / (double)NBIN_SPLINE_GEN;
+
+    // ---- allocate and fit GSL spline ----
+    _alloc_gsl_spline(sp, NVAL, method_spline, cid);
+    gsl_spline_init(sp->spline, x_list, y_list, NVAL);
+    sp->initialized = 1;
+
+    // ---- compute mean / std / val_max on uniform grid ----
+    _compute_stats(sp);
+
+    *mean    = sp->mean;
+    *std_dev = sp->std_dev;
+
+    if (verbose) {
+        printf("\t init_spline[%d] '%s'  method=%s  mode=%s  N=%d"
+               "  x=[%.4f, %.4f]\n",
+               index, sp->name, sp->method,
+               (sp->mode == SPLINE_GEN_MODE_DERIV) ? "DERIV" : "DIRECT",
+               NVAL, sp->xmin, sp->xmax);
+        printf("\t   mean=%.4f  std=%.4f  val_max=%.4f  CID=%s\n",
+               *mean, *std_dev, sp->val_max, cid);
+        fflush(stdout);
+    }
+
+} // end init_spline
+
+
+// ============================================================
+double eval_spline_gen(int index, double x) {
+    // Evaluate spline slot 'index' at a single query point x.
+    // DIRECT: returns interpolated y(x).
+    // DERIV:  returns normalized PDF P(x) = d[CDF]/dx / val_max.
+    // Returns 0.0 for x outside [xmin, xmax].
+
+    char fnam[] = "eval_spline_gen";
+    double y;
+    SPLINE_GEN_DEF *sp = &SPLINE_GEN_ARRAY[index];
+
+    if (!sp->initialized) {
+        sprintf(c1err, "Spline slot %d ('%s') not initialized", index, sp->name);
+        sprintf(c2err, "Call init_spline before eval_spline_gen");
+        errmsg(SEV_FATAL, 0, fnam, c1err, c2err);
+    }
+
+    if (x < sp->xmin || x > sp->xmax) { return 0.0; }
+
+    if (sp->mode == SPLINE_GEN_MODE_DERIV) {
+        y = gsl_spline_eval_deriv(sp->spline, x, sp->acc);
+        if (y < 0.0)  y = 0.0;                // no unphysical negative PDF
+        y /= sp->val_max;                      // normalize so peak = 1
+    } else {
+        y = gsl_spline_eval(sp->spline, x, sp->acc);
+    }
+    return y;
+
+} // end eval_spline_gen
+
+
+// ============================================================
+void eval_spline_gen_array(int index, int N_query,
+                            double *x_query, double *y_out) {
+    // Evaluate spline slot 'index' at each of the N_query points in x_query[].
+    // Writes results into y_out[N_query].
+    // Points outside [xmin, xmax] are set to 0.0 (same as eval_spline_gen).
+    //
+    // Example uses:
+    //   -- compute PDF on a fine z grid for integration
+    //   -- compute logmass(z) on a redshift grid for plotting/debugging
+
+    int i;
+    for (i = 0; i < N_query; i++) {
+        y_out[i] = eval_spline_gen(index, x_query[i]);
+    }
+
+} // end eval_spline_gen_array
+
+
+// ============================================================
+void eval_spline_gen_integral(int index,
+                               double x_center, double x_sigma,
+                               double *mean_out, double *std_out) {
+    // Gaussian-weighted integral of y(x) (or P(x) for DERIV mode).
+    //
+    // Computes:
+    //   mean_out = int[ y(x) * G(x) dx ] / int[ G(x) dx ]
+    //   std_out  = sqrt( int[ (y(x) - mean_out)^2 * G(x) dx ] / int[G(x) dx] )
+    // where G(x) = exp( -0.5 * (x - x_center)^2 / x_sigma^2 ).
+    //
+    // Integration is performed over [max(xmin, x_center - 4*sigma),
+    //                                min(xmax, x_center + 4*sigma)]
+    // on the same grid spacing dx as the stats grid.
+    //
+    // Degenerate case (x_sigma <= 0): returns point estimate at x_center.
+    //
+    // Primary use: logmass(z) marginalized over photo-z Gaussian uncertainty.
+    //   eval_spline_gen_integral(INDEX_LOGMASS, z_ph, z_ph_err,
+    //                            &lm_mean, &lm_std)
+
+    char fnam[] = "eval_spline_gen_integral";
+    SPLINE_GEN_DEF *sp = &SPLINE_GEN_ARRAY[index];
+
+    if (!sp->initialized) {
+        sprintf(c1err, "Spline slot %d ('%s') not initialized", index, sp->name);
+        sprintf(c2err, "Call init_spline before eval_spline_gen_integral");
+        errmsg(SEV_FATAL, 0, fnam, c1err, c2err);
+    }
+
+    // degenerate case: no uncertainty -- just return point estimate
+    if (x_sigma <= 0.0) {
+        *mean_out = eval_spline_gen(index, x_center);
+        *std_out  = 0.0;
+        return;
+    }
+
+    double sigma2  = x_sigma * x_sigma;
+    double dx      = sp->dx;
+
+    // clamp integration range to ± 4 sigma and spline domain
+    double x_lo = fmax(sp->xmin, x_center - 4.0 * x_sigma);
+    double x_hi = fmin(sp->xmax, x_center + 4.0 * x_sigma);
+
+    if (x_lo >= x_hi) {
+        // Gaussian window entirely outside spline domain
+        *mean_out = -9.0;
+        *std_out  =  0.0;
+        return;
+    }
+
+    double sum_yw = 0.0, sum_w = 0.0, sum_sq = 0.0;
+    double x, y, g;
+
+    // first pass: weighted mean
+    for (x = x_lo; x <= x_hi + 0.5 * dx; x += dx) {
+        if (x > x_hi) x = x_hi;
+
+        g = exp(-0.5 * (x - x_center) * (x - x_center) / sigma2);
+
+        if (sp->mode == SPLINE_GEN_MODE_DERIV) {
+            y = gsl_spline_eval_deriv(sp->spline, x, sp->acc);
+            if (y < 0.0) y = 0.0;
+        } else {
+            y = gsl_spline_eval(sp->spline, x, sp->acc);
+        }
+
+        sum_yw += y * g;
+        sum_w  += g;
+    }
+
+    *mean_out = (sum_w > 0.0) ? (sum_yw / sum_w) : -9.0;
+
+    // second pass: weighted std dev
+    for (x = x_lo; x <= x_hi + 0.5 * dx; x += dx) {
+        if (x > x_hi) x = x_hi;
+
+        g = exp(-0.5 * (x - x_center) * (x - x_center) / sigma2);
+
+        if (sp->mode == SPLINE_GEN_MODE_DERIV) {
+            y = gsl_spline_eval_deriv(sp->spline, x, sp->acc);
+            if (y < 0.0) y = 0.0;
+        } else {
+            y = gsl_spline_eval(sp->spline, x, sp->acc);
+        }
+
+        sum_sq += (y - *mean_out) * (y - *mean_out) * g;
+    }
+
+    *std_out = (sum_w > 0.0 && sum_sq > 0.0) ? sqrt(sum_sq / sum_w) : 0.0;
+
+} // end eval_spline_gen_integral
+
+
+// ============================================================
+void dump_spline_gen(int index) {
+    // Print diagnostic summary of slot 'index' to stdout.
+
+    if (!SPLINE_GEN_INIT_DONE) {
+        printf(" xxx dump_spline_gen: not yet initialized\n");
+        return;
+    }
+    SPLINE_GEN_DEF *sp = &SPLINE_GEN_ARRAY[index];
+    printf(" xxx dump_spline_gen[%d]:\n", index);
+    printf(" xxx   name='%s'  method=%s  mode=%s  initialized=%d\n",
+           sp->name, sp->method,
+           (sp->mode == SPLINE_GEN_MODE_DERIV) ? "DERIV" : "DIRECT",
+           sp->initialized);
+    printf(" xxx   NVAL=%d  xmin=%.4f  xmax=%.4f  dx=%.4f\n",
+           sp->NVAL, sp->xmin, sp->xmax, sp->dx);
+    printf(" xxx   mean=%.4f  std_dev=%.4f  val_max=%.4f\n",
+           sp->mean, sp->std_dev, sp->val_max);
+    fflush(stdout);
+
+} // end dump_spline_gen
+
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Fortran wrappers
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// gfortran appends hidden character lengths after all explicit arguments,
+// in the order the character arguments appear in the call.
+// We accept len_cid and len_method explicitly (matching the Fortran call site);
+// the hidden length for any literal string (e.g. "LOGMASS_ZGRID") is appended
+// by gfortran and lands after len_method -- it is unused here since all strings
+// are null-terminated with // char(0) at the call site.
+
+void init_spline__(int *index, int *NVAL,
+                        double *x_list, double *y_list,
+                        char *cid, char *method_spline, char *name,
+                        int *verbose,
+                        double *mean, double *std_dev, int *error_flag,
+                        int len_cid, int len_method) {
+    (void)len_cid;     // strings are null-terminated; lengths not needed
+    (void)len_method;
+    init_spline(*index, *NVAL, x_list, y_list,
+                    cid, method_spline, name, *verbose,
+                    mean, std_dev, error_flag);
 }
 
-double eval_spline(double x) {
-  char fnam[] = "eval_spline";
-  double y = 1.0;
-  return y;
+double eval_spline_gen__(int *index, double *x) {
+    return eval_spline_gen(*index, *x);
 }
 
-
-double eval_spline__(double *x) {
-  return eval_spline(*x);
+void eval_spline_gen_array__(int *index, int *N_query,
+                              double *x_query, double *y_out) {
+    eval_spline_gen_array(*index, *N_query, x_query, y_out);
 }
 
+void eval_spline_gen_integral__(int *index,
+                                 double *x_center, double *x_sigma,
+                                 double *mean_out, double *std_out) {
+    eval_spline_gen_integral(*index, *x_center, *x_sigma, mean_out, std_out);
+}
 
-
-
-
+void dump_spline_gen__(int *index) {
+    dump_spline_gen(*index);
+}

--- a/src/sntools_spline.h
+++ b/src/sntools_spline.h
@@ -1,13 +1,173 @@
-//generalized spline code
+// sntools_spline_gen.h
+//
+// Generalized multi-instance spline interpolation.
+//
+// Core capability: given any arrays x[N] and y[N], fit a spline and then
+// evaluate it at:
+//   - a single query point x            --> eval_spline_gen(index, x)
+//   - an array of query points x[M]     --> eval_spline_gen_array(index, M, x, y_out)
+//
+// Additional capability for photo-z marginalization of a y(z) quantity:
+//   - Gaussian-weighted mean/std of y(x) --> eval_spline_gen_integral(...)
+//   Used for: given logmass(z_grid), return <logmass> marginalized over
+//   a Gaussian photo-z PDF G(z; z_ph, z_ph_err).
+//
+// Supports two evaluation modes, inferred automatically from the 'name' argument:
+//
+//   SPLINE_GEN_MODE_DIRECT  (default; e.g. name = "LOGMASS_ZGRID"):
+//     Spline stores y(x) directly.
+//     eval returns the interpolated y value.
+//
+//   SPLINE_GEN_MODE_DERIV   (triggered when name contains "QUANTILE"):
+//     Spline stores a CDF: x = redshift, y = cumulative probability [0,1].
+//     eval returns  d[CDF]/dx / val_max  -- i.e. the normalized PDF P(x).
+//     This matches and replaces legacy eval_zPDF_spline().
+//
+// Multiple spline slots are maintained simultaneously (MXSPLINE_GEN slots).
+// Each is addressed by an integer index, consistent with snana.F90 constants:
+//   INDEX_SPLINE_QUANTILE_ZPHOT = 1   (DERIV  mode)
+//   INDEX_SPLINE_LOGMASS_ZGRID  = 2   (DIRECT mode)
+//
+// Interpolation methods supported: LINEAR, CUBIC, STEFFEN.
+// STEFFEN requires GSL >= 2.7 (available on Perlmutter; guarded by #ifdef).
+//
+// Design principles:
+//   - No hidden global "current index" state for eval; index is always explicit.
+//   - Style and error handling follows sntools_zPDF_spline.c (R.Chen Jun 2022).
+//   - Fortran (gfortran) wrappers provided with trailing __ convention.
+//
+// Authors : A. Mitra  (May 2026) -- initial implementation
+// Based on : sntools_zPDF_spline.c  by R. Chen (Jun 2022), R. Kessler (updates)
 
 
-void init_spline(int *index, int NVAL, double* x_list, double* y_list,
-                      char *cid, char *method_spline, int verbose,
-                      double *mean, double *std_dev, int *error_flag);
-void init_spline__(int *index, int *NVAL, double* x_list, double* y_list,
-                      char *cid, char *method_spline, int *verbose,
-                      double *mean, double *std_dev, int *error_flag);
+#ifndef SNTOOLS_SPLINE_GEN_H
+#define SNTOOLS_SPLINE_GEN_H
+
+#include <gsl/gsl_errno.h>
+#include <gsl/gsl_spline.h>
+
+// - - - - - - - - - - - - - - - - - - - - - -
+// Method name constants (guarded: also defined in sntools_zPDF_spline.h)
+#ifndef METHOD_SPLINE_LINEAR
+#define METHOD_SPLINE_LINEAR   "LINEAR"
+#define METHOD_SPLINE_CUBIC    "CUBIC"
+#define METHOD_SPLINE_STEFFEN  "STEFFEN"
+#endif
+
+// GSL STEFFEN availability flag (guarded)
+#ifndef GSL_INTERP_STEFFEN
+#define GSL_INTERP_STEFFEN
+#endif
+
+// - - - - - - - - - - - - - - - - - - - - - -
+// Capacity and mode constants
+
+#define MXSPLINE_GEN          10    // max simultaneous spline instances
+#define SPLINE_GEN_MODE_DIRECT  0   // eval returns interpolated y(x)
+#define SPLINE_GEN_MODE_DERIV   1   // eval returns d[CDF]/dx / val_max
+
+#define NBIN_SPLINE_GEN        100  // internal integration grid for stats
 
 
-double eval_spline(double x);
-double eval_spline__(double *x); 
+// - - - - - - - - - - - - - - - - - - - - - -
+// Spline instance struct (exposed for transparency and debugging)
+
+typedef struct {
+    char   name[40];         // user-supplied name, e.g. "LOGMASS_ZGRID"
+    char   method[40];       // interpolation method: LINEAR / CUBIC / STEFFEN
+    int    mode;             // SPLINE_GEN_MODE_DIRECT or SPLINE_GEN_MODE_DERIV
+    int    NVAL;             // number of input (x, y) knots
+    double xmin, xmax;       // range of input x array
+    double dx;               // step size on internal integration grid
+    double mean;             // mean of distribution (see below for definition)
+    double std_dev;          // std dev of distribution
+    double val_max;          // normalization factor (for DERIV: max PDF value)
+    int    initialized;      // 1 if ready to eval, 0 otherwise
+    gsl_interp_accel *acc;   // GSL acceleration object
+    gsl_spline       *spline; // GSL spline object
+} SPLINE_GEN_DEF;
+
+static int SPLINE_GEN_INIT_DONE = 0;  // one-time zeroing flag   
+
+// Exposed array (read-only from caller; do not write directly)
+extern SPLINE_GEN_DEF SPLINE_GEN_ARRAY[MXSPLINE_GEN];
+
+// - - - - - - - - - - - - - - - - - - - - - -
+// C function prototypes
+
+// Initialize spline in slot 'index'.
+// Inputs:
+//   index        : slot index in SPLINE_GEN_ARRAY [0 .. MXSPLINE_GEN-1]
+//   NVAL         : number of knots (>= 2)
+//   x_list[NVAL] : independent variable; must be strictly increasing
+//   y_list[NVAL] : dependent variable
+//   cid          : event ID string for error messages (null-terminated)
+//   method_spline: "LINEAR", "CUBIC", or "STEFFEN"
+//   name         : descriptive label; controls eval mode (null-terminated)
+//   verbose      : > 0 prints summary
+// Outputs:
+//   mean         : mean of the quantity (PDF-weighted z for DERIV; mean y for DIRECT)
+//   std_dev      : corresponding standard deviation
+//   error_flag   :  0  --> ok
+//                  -1  --> x_list contains negative values (bad redshifts)
+//                  -2  --> x_list is not strictly increasing
+void init_spline(int index, int NVAL,
+                     double *x_list, double *y_list,
+                     char *cid, char *method_spline, char *name, int verbose,
+                     double *mean, double *std_dev, int *error_flag);
+
+// Evaluate spline at a single x.
+// DIRECT mode: returns interpolated y(x).
+// DERIV  mode: returns d[CDF]/dx normalized to val_max -- the PDF P(x).
+// Returns 0.0 if x is outside [xmin, xmax].
+double eval_spline_gen(int index, double x);
+
+// Evaluate spline at an array of query points.
+// Fills y_out[N_query] with eval_spline_gen(index, x_query[i]) for each i.
+// Useful for computing a PDF or logmass curve over a redshift grid.
+void eval_spline_gen_array(int index, int N_query,
+                            double *x_query, double *y_out);
+
+// Gaussian-weighted integral of y(x) over the spline domain.
+// For DIRECT mode: marginalizes y(x) over G(x; x_center, x_sigma).
+//   mean_out = int[ y(x) * G(x) dx ] / int[ G(x) dx ]
+//   std_out  = sqrt( int[ (y(x)-mean_out)^2 * G(x) dx ] / int[G(x) dx] )
+// Primary use: logmass(z) marginalized over photo-z uncertainty:
+//   eval_spline_gen_integral(INDEX_LOGMASS, z_ph, z_ph_err, &lm_mean, &lm_std)
+// Also defined for DERIV mode (convolution of PDF with Gaussian).
+// If x_sigma <= 0, returns point estimate at x_center and std_out = 0.
+void eval_spline_gen_integral(int index,
+                               double x_center, double x_sigma,
+                               double *mean_out, double *std_out);
+
+// Print a diagnostic summary of spline slot 'index' to stdout.
+void dump_spline_gen(int index);
+
+// - - - - - - - - - - - - - - - - - - - - - -
+// Fortran (gfortran) wrappers  [ trailing __ naming convention ]
+//
+// Note on character arguments:
+//   gfortran passes hidden character lengths as extra integer arguments
+//   appended after all explicit args, in the order the char args appear.
+//   We accept len_cid and len_method explicitly; the length for the
+//   literal 'name' string is appended automatically by gfortran and ignored.
+
+void   init_spline__(int *index, int *NVAL,
+                          double *x_list, double *y_list,
+                          char *cid, char *method_spline, char *name,
+                          int *verbose,
+                          double *mean, double *std_dev, int *error_flag,
+                          int len_cid, int len_method);
+
+double eval_spline_gen__(int *index, double *x);
+
+void   eval_spline_gen_array__(int *index, int *N_query,
+                                double *x_query, double *y_out);
+
+void   eval_spline_gen_integral__(int *index,
+                                   double *x_center, double *x_sigma,
+                                   double *mean_out, double *std_out);
+
+void   dump_spline_gen__(int *index);
+
+#endif  // SNTOOLS_SPLINE_GEN_H


### PR DESCRIPTION


- sntools_spline.c/h: implement multi-instance GSL spline (replaces stubs)
  - init_spline/eval_spline with CUBIC/STEFFEN/LINEAR method control
  - DERIV mode (name contains QUANTILE): returns dCDF/dx = normalized PDF
  - DIRECT mode: returns interpolated y(x)
  - eval_spline_integral: Gaussian-weighted mean/std for logmass marginalization
  - Fortran-callable wrappers (double-underscore) for all public functions
- snana.F90: wire INDEX_SPLINE_QUANTILE_ZPHOT path in SET_SNHOST_QZPHOT (DEBUG_FLAG==28); add SET_SNHOST_LOGMASS_SPLINE subroutine skeleton
- snlc_fit.F90: call eval_spline for QUANTILE_ZPHOT redshift integration
- Makefile: add sntools_spline.o build rule