### PR TITLE
rename eval_spline_gen -> eval_spline for naming consistency

### DIFF
--- a/src/snana.F90
+++ b/src/snana.F90
@@ -17369,7 +17369,7 @@
     CHARACTER FNAM*20
 
 ! external C functions
-    REAL*8, EXTERNAL :: eval_spline_gen
+    REAL*8, EXTERNAL :: eval_spline
 
 ! ------------- BEGIN ---------------
 
@@ -17427,7 +17427,7 @@
        PRINT*, 'XXX   IERR   = ', IERR
        PRINT*, 'XXX   MEAN   = ', MEAN
        PRINT*, 'XXX   STD    = ', STD
-       CALL dump_spline_gen(INDEX_SPLINE_QUANTILE_ZPHOT)
+       CALL dump_spline(INDEX_SPLINE_QUANTILE_ZPHOT)
        PRINT*, ' '
     else
        ! LEGACY CALL
@@ -17513,7 +17513,7 @@
     Z_PH     = DBLE( SNHOST_ZPHOT(IGAL) )
     Z_PH_ERR = DBLE( SNHOST_ZPHOT_ERR(IGAL) )
 
-    CALL eval_spline_gen_integral(INDEX_SPLINE_LOGMASS_ZGRID, &
+    CALL eval_spline_integral(INDEX_SPLINE_LOGMASS_ZGRID, &
                                   Z_PH, Z_PH_ERR, LM_MEAN, LM_STD)
 
     return

--- a/src/snlc_fit.F90
+++ b/src/snlc_fit.F90
@@ -4766,9 +4766,9 @@
         ,PRIOR_MUPULL  &
         ,GET_RV8  &
         ,eval_zPDF_spline, DLMAG_REF &
-        ,eval_spline, eval_spline_gen
+        ,eval_spline
 
-    EXTERNAL eval_zPDF_spline, eval_spline, eval_spline_gen
+    EXTERNAL eval_zPDF_spline, eval_spline
 
 ! ------------- BEGIN --------------
 
@@ -4873,7 +4873,7 @@
          ! get the probability at this redshift
 
          if(DEBUG_FLAG == 28) then
-            PROBZ = eval_spline_gen(INDEX_SPLINE_QUANTILE_ZPHOT, ZSN)
+            PROBZ = eval_spline(INDEX_SPLINE_QUANTILE_ZPHOT, ZSN)
          else
             PROBZ = eval_zPDF_spline(ZSN)  ! use zPDF from quantiles
          endif

--- a/src/sntools_spline.c
+++ b/src/sntools_spline.c
@@ -242,19 +242,19 @@ void init_spline(int index, int NVAL,
 
 
 // ============================================================
-double eval_spline_gen(int index, double x) {
+double eval_spline(int index, double x) {
     // Evaluate spline slot 'index' at a single query point x.
     // DIRECT: returns interpolated y(x).
     // DERIV:  returns normalized PDF P(x) = d[CDF]/dx / val_max.
     // Returns 0.0 for x outside [xmin, xmax].
 
-    char fnam[] = "eval_spline_gen";
+    char fnam[] = "eval_spline";
     double y;
     SPLINE_GEN_DEF *sp = &SPLINE_GEN_ARRAY[index];
 
     if (!sp->initialized) {
         sprintf(c1err, "Spline slot %d ('%s') not initialized", index, sp->name);
-        sprintf(c2err, "Call init_spline before eval_spline_gen");
+        sprintf(c2err, "Call init_spline before eval_spline");
         errmsg(SEV_FATAL, 0, fnam, c1err, c2err);
     }
 
@@ -269,15 +269,15 @@ double eval_spline_gen(int index, double x) {
     }
     return y;
 
-} // end eval_spline_gen
+} // end eval_spline
 
 
 // ============================================================
-void eval_spline_gen_array(int index, int N_query,
+void eval_spline_array(int index, int N_query,
                             double *x_query, double *y_out) {
     // Evaluate spline slot 'index' at each of the N_query points in x_query[].
     // Writes results into y_out[N_query].
-    // Points outside [xmin, xmax] are set to 0.0 (same as eval_spline_gen).
+    // Points outside [xmin, xmax] are set to 0.0 (same as eval_spline).
     //
     // Example uses:
     //   -- compute PDF on a fine z grid for integration
@@ -285,14 +285,14 @@ void eval_spline_gen_array(int index, int N_query,
 
     int i;
     for (i = 0; i < N_query; i++) {
-        y_out[i] = eval_spline_gen(index, x_query[i]);
+        y_out[i] = eval_spline(index, x_query[i]);
     }
 
-} // end eval_spline_gen_array
+} // end eval_spline_array
 
 
 // ============================================================
-void eval_spline_gen_integral(int index,
+void eval_spline_integral(int index,
                                double x_center, double x_sigma,
                                double *mean_out, double *std_out) {
     // Gaussian-weighted integral of y(x) (or P(x) for DERIV mode).
@@ -309,21 +309,21 @@ void eval_spline_gen_integral(int index,
     // Degenerate case (x_sigma <= 0): returns point estimate at x_center.
     //
     // Primary use: logmass(z) marginalized over photo-z Gaussian uncertainty.
-    //   eval_spline_gen_integral(INDEX_LOGMASS, z_ph, z_ph_err,
+    //   eval_spline_integral(INDEX_LOGMASS, z_ph, z_ph_err,
     //                            &lm_mean, &lm_std)
 
-    char fnam[] = "eval_spline_gen_integral";
+    char fnam[] = "eval_spline_integral";
     SPLINE_GEN_DEF *sp = &SPLINE_GEN_ARRAY[index];
 
     if (!sp->initialized) {
         sprintf(c1err, "Spline slot %d ('%s') not initialized", index, sp->name);
-        sprintf(c2err, "Call init_spline before eval_spline_gen_integral");
+        sprintf(c2err, "Call init_spline before eval_spline_integral");
         errmsg(SEV_FATAL, 0, fnam, c1err, c2err);
     }
 
     // degenerate case: no uncertainty -- just return point estimate
     if (x_sigma <= 0.0) {
-        *mean_out = eval_spline_gen(index, x_center);
+        *mean_out = eval_spline(index, x_center);
         *std_out  = 0.0;
         return;
     }
@@ -382,19 +382,19 @@ void eval_spline_gen_integral(int index,
 
     *std_out = (sum_w > 0.0 && sum_sq > 0.0) ? sqrt(sum_sq / sum_w) : 0.0;
 
-} // end eval_spline_gen_integral
+} // end eval_spline_integral
 
 
 // ============================================================
-void dump_spline_gen(int index) {
+void dump_spline(int index) {
     // Print diagnostic summary of slot 'index' to stdout.
 
     if (!SPLINE_GEN_INIT_DONE) {
-        printf(" xxx dump_spline_gen: not yet initialized\n");
+        printf(" xxx dump_spline: not yet initialized\n");
         return;
     }
     SPLINE_GEN_DEF *sp = &SPLINE_GEN_ARRAY[index];
-    printf(" xxx dump_spline_gen[%d]:\n", index);
+    printf(" xxx dump_spline[%d]:\n", index);
     printf(" xxx   name='%s'  method=%s  mode=%s  initialized=%d\n",
            sp->name, sp->method,
            (sp->mode == SPLINE_GEN_MODE_DERIV) ? "DERIV" : "DIRECT",
@@ -405,7 +405,7 @@ void dump_spline_gen(int index) {
            sp->mean, sp->std_dev, sp->val_max);
     fflush(stdout);
 
-} // end dump_spline_gen
+} // end dump_spline
 
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -431,21 +431,21 @@ void init_spline__(int *index, int *NVAL,
                     mean, std_dev, error_flag);
 }
 
-double eval_spline_gen__(int *index, double *x) {
-    return eval_spline_gen(*index, *x);
+double eval_spline__(int *index, double *x) {
+    return eval_spline(*index, *x);
 }
 
-void eval_spline_gen_array__(int *index, int *N_query,
+void eval_spline_array__(int *index, int *N_query,
                               double *x_query, double *y_out) {
-    eval_spline_gen_array(*index, *N_query, x_query, y_out);
+    eval_spline_array(*index, *N_query, x_query, y_out);
 }
 
-void eval_spline_gen_integral__(int *index,
+void eval_spline_integral__(int *index,
                                  double *x_center, double *x_sigma,
                                  double *mean_out, double *std_out) {
-    eval_spline_gen_integral(*index, *x_center, *x_sigma, mean_out, std_out);
+    eval_spline_integral(*index, *x_center, *x_sigma, mean_out, std_out);
 }
 
-void dump_spline_gen__(int *index) {
-    dump_spline_gen(*index);
+void dump_spline__(int *index) {
+    dump_spline(*index);
 }

--- a/src/sntools_spline.h
+++ b/src/sntools_spline.h
@@ -4,11 +4,11 @@
 //
 // Core capability: given any arrays x[N] and y[N], fit a spline and then
 // evaluate it at:
-//   - a single query point x            --> eval_spline_gen(index, x)
-//   - an array of query points x[M]     --> eval_spline_gen_array(index, M, x, y_out)
+//   - a single query point x            --> eval_spline(index, x)
+//   - an array of query points x[M]     --> eval_spline_array(index, M, x, y_out)
 //
 // Additional capability for photo-z marginalization of a y(z) quantity:
-//   - Gaussian-weighted mean/std of y(x) --> eval_spline_gen_integral(...)
+//   - Gaussian-weighted mean/std of y(x) --> eval_spline_integral(...)
 //   Used for: given logmass(z_grid), return <logmass> marginalized over
 //   a Gaussian photo-z PDF G(z; z_ph, z_ph_err).
 //
@@ -56,7 +56,7 @@
 
 // GSL STEFFEN availability flag (guarded)
 #ifndef GSL_INTERP_STEFFEN
-#define GSL_INTERP_STEFFENxxx
+#define GSL_INTERP_STEFFEN 
 #endif
 
 
@@ -121,12 +121,12 @@ void init_spline(int index, int NVAL,
 // DIRECT mode: returns interpolated y(x).
 // DERIV  mode: returns d[CDF]/dx normalized to val_max -- the PDF P(x).
 // Returns 0.0 if x is outside [xmin, xmax].
-double eval_spline_gen(int index, double x);
+double eval_spline(int index, double x);
 
 // Evaluate spline at an array of query points.
-// Fills y_out[N_query] with eval_spline_gen(index, x_query[i]) for each i.
+// Fills y_out[N_query] with eval_spline(index, x_query[i]) for each i.
 // Useful for computing a PDF or logmass curve over a redshift grid.
-void eval_spline_gen_array(int index, int N_query,
+void eval_spline_array(int index, int N_query,
                             double *x_query, double *y_out);
 
 // Gaussian-weighted integral of y(x) over the spline domain.
@@ -134,15 +134,15 @@ void eval_spline_gen_array(int index, int N_query,
 //   mean_out = int[ y(x) * G(x) dx ] / int[ G(x) dx ]
 //   std_out  = sqrt( int[ (y(x)-mean_out)^2 * G(x) dx ] / int[G(x) dx] )
 // Primary use: logmass(z) marginalized over photo-z uncertainty:
-//   eval_spline_gen_integral(INDEX_LOGMASS, z_ph, z_ph_err, &lm_mean, &lm_std)
+//   eval_spline_integral(INDEX_LOGMASS, z_ph, z_ph_err, &lm_mean, &lm_std)
 // Also defined for DERIV mode (convolution of PDF with Gaussian).
 // If x_sigma <= 0, returns point estimate at x_center and std_out = 0.
-void eval_spline_gen_integral(int index,
+void eval_spline_integral(int index,
                                double x_center, double x_sigma,
                                double *mean_out, double *std_out);
 
 // Print a diagnostic summary of spline slot 'index' to stdout.
-void dump_spline_gen(int index);
+void dump_spline(int index);
 
 // - - - - - - - - - - - - - - - - - - - - - -
 // Fortran (gfortran) wrappers  [ trailing __ naming convention ]
@@ -160,15 +160,15 @@ void   init_spline__(int *index, int *NVAL,
                           double *mean, double *std_dev, int *error_flag,
                           int len_cid, int len_method);
 
-double eval_spline_gen__(int *index, double *x);
+double eval_spline__(int *index, double *x);
 
-void   eval_spline_gen_array__(int *index, int *N_query,
+void   eval_spline_array__(int *index, int *N_query,
                                 double *x_query, double *y_out);
 
-void   eval_spline_gen_integral__(int *index,
+void   eval_spline_integral__(int *index,
                                    double *x_center, double *x_sigma,
                                    double *mean_out, double *std_out);
 
-void   dump_spline_gen__(int *index);
+void   dump_spline__(int *index);
 
 #endif  // SNTOOLS_SPLINE_GEN_H


### PR DESCRIPTION
All public functions in sntools_spline.c now follow uniform naming:
  init_spline, eval_spline, eval_spline_array, eval_spline_integral,
  dump_spline  (drop _gen suffix throughout)

Files changed: sntools_spline.c/h, snana.F90, snlc_fit.F90