### PR TITLE
Increase size of logic array in sntools_trigger.c

### DIFF
--- a/src/sntools_trigger.c
+++ b/src/sntools_trigger.c
@@ -881,7 +881,7 @@ void  init_SEARCHEFF_LOGIC(char *survey) {
 
   char 
      cline[MXPATHLEN+40]
-    ,logic[100]
+    ,logic[200] # May 2026 RP edited to allow for additional logic conditions
     ,c_get[100]
     ,surveykey[60]
     ,logicFile_Default[] = "SEARCHEFF_PIPELINE_LOGIC.DAT"


### PR DESCRIPTION
Increased the size of the 'logic' array to accommodate additional logic conditions.