### PR TITLE
Always exclude mag error columns from HDF5 selection in convert_galaxy_cat_to_pandas

### DIFF
--- a/util/make_hostlib_diffsky.py
+++ b/util/make_hostlib_diffsky.py
@@ -767,11 +767,14 @@ def convert_galaxy_cat_to_pandas(galaxy_cat, config):
     # exclude columns computed at pandas level — not present in HDF5 catalog
     cat_var_list = [v for v in cat_var_list if v not in ADDCOL_PD_NAMES]
 
+    # Always exclude mag error columns — not in HDF5, computed in add_col_pd
+    mag_bands    = _get_mag_bands(config)
+    mag_err_cols = [b + '_err' for b in mag_bands]
+    cat_var_list = [v for v in cat_var_list if v not in mag_err_cols]
+
     if KEY_OVERRIDE_FILE in config:
-        # Exclude mag band columns and their errors — not in HDF5, will be injected from parquet
-        mag_bands    = _get_mag_bands(config)
-        mag_err_cols = [b + '_err' for b in mag_bands]
-        cat_var_list = [v for v in cat_var_list if v not in mag_bands and v not in mag_err_cols]
+        # Also exclude raw mag band columns — not in HDF5, will be injected from parquet
+        cat_var_list = [v for v in cat_var_list if v not in mag_bands]
         # Add core_tag temporarily — needed as join key in inject_mag_columns
         if 'core_tag' not in cat_var_list:
             cat_var_list.append('core_tag')


### PR DESCRIPTION
### The Issue
When running the SNANA utility in native magnitude mode (without  OVERRIDE_FILE ), the script parses the                
  HOSTLIB_VARNAMES_MAP  config and tries to load all mapped columns from the HDF5 catalog.                                
  This includes the magnitude error columns (e.g.,  lsst_g_err ). However, these error columns do not exist in the HDF5   
  files—they are computed at the Pandas level inside  add_col_pd . Because of this, the script crashed when trying to     
  query them from  opencosmo  during catalog loading.  

 ### The Fix                                                                                                             
                                                                                                                          
  I updated the  convert_galaxy_cat_to_pandas  function in make_hostlib_diffsky.py to always exclude the magnitude error
columns ( 
  mag_err_cols ) from the HDF5 catalog selection list, regardless of whether  OVERRIDE_FILE  is configured. This lets the 
  base catalog load successfully, and the error columns are then correctly calculated and appended later at the Pandas    
  level.       