### PR TITLE
fix make_hostlib_diffsky: exclude synth_cores and dedup serial_tag

### DIFF
--- a/util/make_hostlib_diffsky.py
+++ b/util/make_hostlib_diffsky.py
@@ -341,6 +341,16 @@ def inject_mag_columns(df_cat, config):
         cols_to_merge = [rename_map.get(c, c) for c in cols_to_merge]
 
     # Left-merge on core_tag (df_cat) ↔ serial_tag (parquet) — both int64, exact match
+    # Deduplicate parquet on serial_tag first: LastJourney light-cones can contain
+    # periodic-box replicas of the same halo (same core_tag, different sky position).
+    # Without dedup the merge explodes those HDF5 rows into 2 rows with the same
+    # sequential GALID but different magnitudes → duplicate GALID in SNANA HOSTLIB.
+    n_dup = df_mag['serial_tag'].duplicated().sum()
+    if n_dup > 0:
+        logging.warning(f"  inject_mag_columns: dropping {n_dup} duplicate serial_tag rows "
+                        f"from override table (light-cone periodic replicas); "
+                        f"affected galaxies get first-occurrence magnitudes")
+        df_mag = df_mag.drop_duplicates(subset=['serial_tag'], keep='first')
     n_before = len(df_cat)
     df_cat = df_cat.merge(
         df_mag[cols_to_merge].rename(columns={'serial_tag': 'core_tag'}),
@@ -515,7 +525,7 @@ def read_galaxy_cat(args, config):
     
     logging.info(f"Read {n_file} galaxy catalog files from {cat_dir}")
 
-    ds = oc.open(*catalog_files, synth_cores=True)
+    ds = oc.open(*catalog_files, synth_cores=False)
     
     n_row = len(ds)
     logging.info(f"Done reading dataset with {n_row:,} rows")


### PR DESCRIPTION
Two bugs in OVERRIDE_FILE mag injection mode:

1. synth_cores=True caused opencosmo to return ~264M rows (including ~248M synthetic satellite cores not present in the h5py patches). The parquet was built from h5py only, so 78% of rows had no mag match and were silently filled with 0.0. Fix: synth_cores=False returns only the 15.7M real cores, all covered by parquet.

2. LastJourney light-cones contain 260 halos replicated at two sky positions (periodic-box wraps). Same core_tag appears twice in parquet → left-merge explodes each HDF5 row into 2 rows with the same sequential GALID. Fix: drop_duplicates on serial_tag before merge, keeping first occurrence.

Verified on DES_DIFFSKY_Z18 run: merged mags for 1,219,522/1,219,522 galaxies (100% match, 0 unmatched).