### PR TITLE
Bug Fix, off-by-one dropping first entry of inline SNCCID_IGNORE list

### DIFF
--- a/src/snana.F90
+++ b/src/snana.F90
@@ -11601,8 +11601,8 @@
     i = 1
     DO WHILE ( SNCCID_IGNORE(i) .NE. ' ' )
        CALL NMLCHECK_SNCCID("SNCCID_IGNORE",SNCCID_IGNORE(i))
-       i = i + 1
        SNCCID_IGNORE_ALL(i) = SNCCID_IGNORE(i)
+       i = i + 1
     END DO
     NCCID_IGNORE = i - 1
 


### PR DESCRIPTION
## Bug

`INIT_SNCID_LISTS` in `src/snana.F90` builds the internal ignore-match
array `SNCCID_IGNORE_ALL` from the namelist array `SNCCID_IGNORE` with:

```fortran
i = 1
DO WHILE ( SNCCID_IGNORE(i) .NE. ' ' )
   CALL NMLCHECK_SNCCID("SNCCID_IGNORE",SNCCID_IGNORE(i))
   i = i + 1
   SNCCID_IGNORE_ALL(i) = SNCCID_IGNORE(i)
END DO
NCCID_IGNORE = i - 1
```

`i` is incremented **before** it's used to store, so every entry is
written one slot ahead of where it was read from. Net effect for an
N-entry list: `SNCCID_IGNORE_ALL(1)` is never written, so the **first
CID in the user's list is silently never stored** anywhere the matcher
checks. `NCCID_IGNORE = i - 1` still comes out correct (it only counts
loop iterations), so the log line `IGNORE N CIDs from SNCCID_IGNORE`
reports the right count while the first CID is never actually matched
by the brute-force check against `SNCCID_IGNORE_ALL` later in this
file (the `DO 40 i = 1, NCCID_IGNORE` loop that checks CID rejection).

The sibling path for file-based lists (`SNCID_IGNORE_FILE` ->
`RDSNIGNORE`) increments `NCCID_IGNORE` and then stores at the new
index, which is the correct order — only the inline namelist array
path has the bug.

## Reproduction

```
&SNLCINP
  SNCCID_IGNORE = 'CID_A','CID_B','CID_C'
&END
```

Expected: all three CIDs (`CID_A`, `CID_B`, `CID_C`) are excluded from
the fit/sim.

Actual: log reports `IGNORE 3 CIDs from SNCCID_IGNORE`, but `CID_A`
(the first entry) is still processed normally; only `CID_B` and
`CID_C` are actually ignored.

## Fix

Swap the increment and the store so the index used to read and the
index used to write are the same on each iteration (see diff). This
does not change `NCCID_IGNORE`'s value (still `i - 1` after the loop),
only which slots get populated.